### PR TITLE
prevent multiple DOM autofocuses

### DIFF
--- a/src/containers/Login/Login.js
+++ b/src/containers/Login/Login.js
@@ -42,7 +42,6 @@ class Login extends Component {
                         error={this.props.fail}
                     />
                     <TextField
-                        autoFocus
                         margin="dense"
                         id="password"
                         label="Password"


### PR DESCRIPTION
by deleting this line, the login dialog will autofocus on email field instead of password field