### PR TITLE
fix: top menu on mobile view

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -25,6 +25,7 @@ import {
 } from "@mui/material";
 import { AccountBox } from "@mui/icons-material";
 import Button from "@mui/material/Button";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import CachedAvatar from "@comp/profile/cached-avatar";
 import MenuIcon from "@mui/icons-material/Menu";
 import HelpIcon from "@mui/icons-material/Help";
@@ -43,6 +44,8 @@ import { selectIsHeaderDrawerOpen } from "@comp/menu-ui/selectors";
 
 export const Header = () => {
     const dispatch = useDispatch();
+    const isCompactViewport = useMediaQuery("(max-width:900px)");
+    const mobileView = isMobile() || isCompactViewport;
 
     const authenticated = useSelector(
         (store: RootState) => store.LoginReducer.authenticated
@@ -204,19 +207,23 @@ export const Header = () => {
                 <Toolbar disableGutters={true} css={SS.toolbar}>
                     {burgerMenu}
 
+                    {routeIsEditor && activeProjectUid && mobileView && (
+                        <MenuBar />
+                    )}
+
                     <CSLogo size={38} interactive={true} />
 
-                    {routeIsEditor &&
-                        activeProjectUid &&
-                        (isOwner || !isMobile()) && <MenuBar />}
+                    {routeIsEditor && activeProjectUid && !mobileView && (
+                        <MenuBar />
+                    )}
                     <div style={{ flexGrow: 1 }} />
                     <div css={SS.headerRightSideGroup}>
-                        {routeIsEditor && activeProjectUid && !isMobile() && (
+                        {routeIsEditor && activeProjectUid && (
                             <TargetControls
                                 activeProjectUid={activeProjectUid}
                             />
                         )}
-                        {routeIsEditor && activeProjectUid && !isMobile() && (
+                        {routeIsEditor && activeProjectUid && !mobileView && (
                             <SocialControls
                                 activeProjectUid={activeProjectUid}
                             />
@@ -285,7 +292,7 @@ export const Header = () => {
                         </List> */}
                 </div>
             </Drawer>
-            {routeIsEditor && !isOwner && !isMobile() && <ProjectProfileMeta />}
+            {routeIsEditor && !isOwner && !mobileView && <ProjectProfileMeta />}
         </>
     );
 };

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { RootState, useDispatch, useSelector } from "@root/store";
 import { selectIsOwner } from "@comp/project-editor/selectors";
 import {
@@ -38,6 +38,8 @@ import ProjectProfileMeta from "./project-profile-meta";
 import { TargetControls } from "@comp/target-controls";
 import SocialControls from "@comp/social-controls/social-controls";
 import { isMobile } from "@root/utils";
+import { closeHeaderDrawer, openHeaderDrawer } from "@comp/menu-ui/actions";
+import { selectIsHeaderDrawerOpen } from "@comp/menu-ui/selectors";
 
 export const Header = () => {
     const dispatch = useDispatch();
@@ -73,7 +75,7 @@ export const Header = () => {
 
     const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
 
-    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    const isDrawerOpen = useSelector(selectIsHeaderDrawerOpen);
 
     const handleProfileMenuOpen = () => {
         setIsProfileMenuOpen(true);
@@ -82,6 +84,23 @@ export const Header = () => {
     const handleProfileMenuClose = () => {
         setIsProfileMenuOpen(false);
     };
+
+    useEffect(() => {
+        const closeOnEscape = (event: KeyboardEvent) => {
+            if (event.key !== "Escape") {
+                return;
+            }
+
+            handleProfileMenuClose();
+            dispatch(closeHeaderDrawer());
+        };
+
+        window.addEventListener("keydown", closeOnEscape);
+
+        return () => {
+            window.removeEventListener("keydown", closeOnEscape);
+        };
+    }, [dispatch]);
 
     const logout = () => dispatch(loginActions.logOut());
     const openLoginDialog = () => dispatch(loginActions.openLoginDialog());
@@ -95,17 +114,22 @@ export const Header = () => {
     const userMenu = () => (
         <div css={SS.userMenu}>
             <IconButton
-                aria-owns={isProfileMenuOpen ? "menu-appbar" : undefined}
+                aria-controls={
+                    isProfileMenuOpen ? "user-menu-appbar" : undefined
+                }
+                aria-expanded={isProfileMenuOpen}
                 data-tip="UserMenu"
                 aria-haspopup="true"
+                aria-label="Open user menu"
                 color="inherit"
                 onClick={handleProfileMenuOpen}
                 ref={anchorElement}
                 component="button"
             >
-                {avatar as any}
+                {avatar}
             </IconButton>
             <Menu
+                id="user-menu-appbar"
                 css={SS.menuPaper}
                 anchorEl={anchorElement.current}
                 anchorOrigin={{
@@ -158,8 +182,12 @@ export const Header = () => {
             <IconButton
                 color="inherit"
                 aria-label="open drawer"
+                aria-controls={
+                    isDrawerOpen ? "top-navigation-drawer" : undefined
+                }
+                aria-expanded={isDrawerOpen}
                 data-tip="Open drawer"
-                onClick={() => setIsDrawerOpen(true)}
+                onClick={() => dispatch(openHeaderDrawer())}
                 edge="start"
                 css={SS.menuButton}
             >
@@ -183,12 +211,12 @@ export const Header = () => {
                         (isOwner || !isMobile()) && <MenuBar />}
                     <div style={{ flexGrow: 1 }} />
                     <div css={SS.headerRightSideGroup}>
-                        {routeIsEditor && activeProjectUid && (
+                        {routeIsEditor && activeProjectUid && !isMobile() && (
                             <TargetControls
                                 activeProjectUid={activeProjectUid}
                             />
                         )}
-                        {routeIsEditor && activeProjectUid && (
+                        {routeIsEditor && activeProjectUid && !isMobile() && (
                             <SocialControls
                                 activeProjectUid={activeProjectUid}
                             />
@@ -198,7 +226,11 @@ export const Header = () => {
                 </Toolbar>
             </AppBar>
 
-            <Drawer open={isDrawerOpen} onClose={() => setIsDrawerOpen(false)}>
+            <Drawer
+                id="top-navigation-drawer"
+                open={isDrawerOpen}
+                onClose={() => dispatch(closeHeaderDrawer())}
+            >
                 <div css={SS.drawer}>
                     <div css={SS.drawerHeader}>
                         <h2>Csound Web-IDE</h2>

--- a/src/components/header/styles.tsx
+++ b/src/components/header/styles.tsx
@@ -10,11 +10,12 @@ export const headerRoot = (theme: Theme): SerializedStyles => css`
     background-color: ${theme.headerBackground};
     z-index: 3;
     & > div {
-       height ${headerHeight}px;
+        height: ${headerHeight}px;
     }
     font-family: ${theme.font.regular};
     /* because of mui's <Menu> */
-    padding: 0!important;
+    padding: 0 !important;
+    overflow-x: clip;
 `;
 
 export const drawer = css`
@@ -39,7 +40,10 @@ export const menuItemLink = css`
 
 export const toolbar = css`
     display: flex;
-    justify-content: space-between;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    min-width: 0;
 `;
 
 export const avatar = css`
@@ -55,6 +59,10 @@ export const userMenu = css`
     margin-right: 12px;
     & > button {
         padding: 0 !important;
+    }
+
+    @media (max-width: 900px) {
+        margin-right: 8px;
     }
 `;
 
@@ -85,7 +93,8 @@ export const headerRightSideGroup = css`
     top: 0px;
     height: 42px;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
+    flex-shrink: 0;
 
     & > div {
         height: 42px;
@@ -94,10 +103,22 @@ export const headerRightSideGroup = css`
         display: inline;
         vertical-align: middle;
     }
+
+    @media (max-width: 900px) {
+        margin-left: 4px;
+
+        & > div {
+            margin-right: 2px;
+        }
+    }
 `;
 
 export const spacer = css`
     margin-left: 12px;
+
+    @media (max-width: 900px) {
+        margin-left: 8px;
+    }
 `;
 
 export const clearfixHeader = css`

--- a/src/components/menu-bar/menu-bar.tsx
+++ b/src/components/menu-bar/menu-bar.tsx
@@ -11,12 +11,18 @@ import SelectedIcon from "@mui/icons-material/DoneSharp";
 import NestedMenuIcon from "@mui/icons-material/ArrowRightSharp";
 import MenuIcon from "@mui/icons-material/Menu";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
+import EditIcon from "@mui/icons-material/Edit";
+import BuildIcon from "@mui/icons-material/Build";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import SettingsInputComponentIcon from "@mui/icons-material/SettingsInputComponent";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import * as SS from "./styles";
 import { hr as hrCss } from "@styles/_common";
 import { MenuItemDef } from "./types";
 import { useSetConsole } from "@comp/console/context";
 import { invokeHotKeyCallback } from "@comp/hot-keys/actions";
-import { BindingsMap } from "@comp/hot-keys/types";
 import { humanizeKeySequence } from "@comp/hot-keys/utils";
 import { showTargetsConfigDialog } from "@comp/target-controls/actions";
 import { exportProject } from "@comp/projects/actions";
@@ -33,21 +39,23 @@ import { showKeyboardShortcuts } from "@comp/site-documents/actions";
 import { openBottomTab } from "@comp/bottom-tabs/actions";
 import { isMobile } from "@root/utils";
 import {
+    closeMobileDock,
     closeMobileTopMenu,
     popMobileTopMenuPath,
     pushMobileTopMenuPath,
     resetMobileTopMenuPath,
+    toggleMobileDock,
     toggleMobileTopMenu
 } from "@comp/menu-ui/actions";
 import {
+    selectIsMobileDockOpen,
     selectIsMobileTopMenuOpen,
     selectMobileTopMenuPath
 } from "@comp/menu-ui/selectors";
 
 export function MenuBar() {
     const setConsole = useSetConsole();
-    const menuRootRef = useRef<HTMLUListElement | null>(null);
-    const firstMobileItemRef = useRef<HTMLLIElement | null>(null);
+    const menuRootRef = useRef<HTMLDivElement | null>(null);
 
     const activeProjectUid = useSelector(
         (store: RootState) => store.ProjectsReducer.activeProjectUid || ""
@@ -86,10 +94,12 @@ export function MenuBar() {
 
     const isMobileMenuOpen = useSelector(selectIsMobileTopMenuOpen);
     const mobilePath = useSelector(selectMobileTopMenuPath);
+    const isMobileDockVisible = useSelector(selectIsMobileDockOpen);
 
     const [isSabEnabled, setIsSabEnabled] = useLocalStorage("sab", "false");
     const [openPath, setOpenPath] = useState<number[]>([]);
-    const mobileView = isMobile();
+    const isCompactViewport = useMediaQuery("(max-width:900px)");
+    const mobileView = isMobile() || isCompactViewport;
 
     const menuBarItems: MenuItemDef[] = useMemo(
         () => [
@@ -354,6 +364,7 @@ export function MenuBar() {
                 return;
             }
             setOpenPath([]);
+            dispatch(closeMobileDock());
             dispatch(closeMobileTopMenu());
         };
 
@@ -369,8 +380,31 @@ export function MenuBar() {
             return;
         }
 
-        firstMobileItemRef.current?.focus();
+        const firstItem = menuRootRef.current?.querySelector<HTMLElement>(
+            '#mobile-top-menu [role="menuitem"]'
+        );
+        firstItem?.focus();
     }, [isMobileMenuOpen, mobilePath]);
+
+    useEffect(() => {
+        const className = "mobile-left-menu-docked";
+        if (mobileView && isMobileDockVisible) {
+            document.body.classList.add(className);
+        } else {
+            document.body.classList.remove(className);
+        }
+
+        return () => {
+            document.body.classList.remove(className);
+        };
+    }, [isMobileDockVisible, mobileView]);
+
+    // Close dock and panel state when component unmounts (e.g. navigating away)
+    useEffect(() => {
+        return () => {
+            dispatch(closeMobileDock());
+        };
+    }, [dispatch]);
 
     const runMenuItem = useCallback(
         (item: MenuItemDef, event?: React.MouseEvent) => {
@@ -412,6 +446,25 @@ export function MenuBar() {
             return false;
         }
         return targetPath.every((value, index) => value === openedPath[index]);
+    };
+
+    const topLevelIcon = (label: string | undefined): React.ReactNode => {
+        switch (label) {
+            case "File":
+                return <InsertDriveFileIcon />;
+            case "Edit":
+                return <EditIcon />;
+            case "Project":
+                return <BuildIcon />;
+            case "View":
+                return <VisibilityIcon />;
+            case "I/O":
+                return <SettingsInputComponentIcon />;
+            case "Help":
+                return <HelpOutlineIcon />;
+            default:
+                return <MenuIcon />;
+        }
     };
 
     const reduceRow = (
@@ -503,123 +556,212 @@ export function MenuBar() {
         });
 
     const mobileColumns = () => {
-        const currentItems = getItemsAtPath(menuBarItems, mobilePath);
+        const activeTopLevelIndex = mobilePath.length > 0 ? mobilePath[0] : 0;
+        const activePath =
+            mobilePath.length > 0 ? mobilePath : [activeTopLevelIndex];
+        const currentItems = getItemsAtPath(menuBarItems, activePath);
+        const activeTopLevelItem = menuBarItems[activeTopLevelIndex];
         const currentLabel =
-            mobilePath.length > 0
-                ? getItemsAtPath(menuBarItems, mobilePath.slice(0, -1))[
-                      mobilePath[mobilePath.length - 1]
+            activePath.length > 1
+                ? getItemsAtPath(menuBarItems, activePath.slice(0, -1))[
+                      activePath[activePath.length - 1]
                   ]?.label
-                : "Menu";
+                : activeTopLevelItem?.label || "Menu";
+
+        const toggleDockFromHeader = () => {
+            if (isMobileDockVisible) {
+                dispatch(closeMobileDock());
+                return;
+            }
+
+            dispatch(toggleMobileDock());
+            dispatch(toggleMobileTopMenu());
+            dispatch(pushMobileTopMenuPath(0));
+        };
+
+        const closeMobileMenu = () => {
+            dispatch(closeMobileTopMenu());
+            dispatch(resetMobileTopMenuPath());
+        };
+
+        const selectTopLevel = (index: number) => {
+            if (
+                isMobileMenuOpen &&
+                mobilePath.length === 1 &&
+                mobilePath[0] === index
+            ) {
+                closeMobileMenu();
+                return;
+            }
+
+            if (!isMobileMenuOpen) {
+                dispatch(toggleMobileTopMenu());
+            }
+            dispatch(resetMobileTopMenuPath());
+            dispatch(pushMobileTopMenuPath(index));
+        };
 
         return (
             <>
                 <button
                     type="button"
-                    css={SS.mobileMenuButton}
-                    aria-label="Toggle menu"
-                    aria-haspopup="menu"
-                    aria-controls="mobile-top-menu"
-                    aria-expanded={isMobileMenuOpen}
-                    onClick={() => {
-                        dispatch(toggleMobileTopMenu());
-                        if (isMobileMenuOpen) {
-                            dispatch(resetMobileTopMenuPath());
-                        }
-                    }}
+                    css={SS.mobileTopTriggerButton(isMobileDockVisible)}
+                    aria-label={
+                        isMobileDockVisible
+                            ? "Close editor menu"
+                            : "Open editor menu"
+                    }
+                    aria-expanded={isMobileDockVisible}
+                    onClick={toggleDockFromHeader}
                 >
-                    <MenuIcon css={SS.mobileMenuIcon} />
-                    <span>Menu</span>
+                    <MenuIcon />
                 </button>
-                {isMobileMenuOpen && (
-                    <ul
-                        id="mobile-top-menu"
-                        role="menu"
-                        css={SS.mobileDropdownList}
-                    >
-                        {mobilePath.length > 0 && (
-                            <li
-                                ref={firstMobileItemRef}
-                                role="menuitem"
-                                tabIndex={0}
-                                css={SS.mobileBackItem}
-                                onClick={() => {
-                                    dispatch(popMobileTopMenuPath());
-                                }}
-                            >
-                                <ArrowBackIcon css={SS.mobileBackIcon} />
-                                <span>{currentLabel}</span>
-                            </li>
-                        )}
 
-                        {currentItems.map((item, index) => {
-                            if (item.seperator) {
-                                return <hr key={index} css={hrCss} />;
-                            }
+                {isMobileDockVisible && (
+                    <div
+                        css={SS.mobileDockBackdrop}
+                        onClick={() => dispatch(closeMobileDock())}
+                        aria-hidden="true"
+                    />
+                )}
 
-                            const hasChild = !!item.submenu;
+                {isMobileDockVisible && (
+                    <div css={SS.mobileDock}>
+                        <div css={SS.mobileRail}>
+                            <ul css={SS.mobileRailList}>
+                                {menuBarItems.map((item, index) => (
+                                    <li key={item.label || index}>
+                                        <button
+                                            type="button"
+                                            css={SS.mobileRailButton(
+                                                index === activeTopLevelIndex &&
+                                                    isMobileMenuOpen
+                                            )}
+                                            onClick={() => {
+                                                selectTopLevel(index);
+                                            }}
+                                            aria-label={item.label || "Menu"}
+                                        >
+                                            <span css={SS.mobileRailIcon}>
+                                                {topLevelIcon(item.label)}
+                                            </span>
+                                            <span css={SS.mobileRailText}>
+                                                {item.label}
+                                            </span>
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
 
-                            return (
-                                <li
-                                    key={index}
-                                    ref={
-                                        mobilePath.length === 0 && index === 0
-                                            ? firstMobileItemRef
-                                            : null
-                                    }
-                                    role="menuitem"
-                                    tabIndex={0}
-                                    css={
-                                        item.disabled
-                                            ? SS.listItemDisabled
-                                            : SS.listItem
-                                    }
-                                    onClick={(event) => {
-                                        if (item.disabled) {
-                                            event.preventDefault();
-                                            return;
-                                        }
-
-                                        if (hasChild) {
-                                            dispatch(
-                                                pushMobileTopMenuPath(index)
-                                            );
-                                            return;
-                                        }
-
-                                        runMenuItem(item, event);
-                                    }}
-                                    onKeyDown={(event) => {
-                                        if (
-                                            event.key === "Enter" ||
-                                            event.key === " "
-                                        ) {
-                                            event.preventDefault();
-                                            if (item.disabled) {
-                                                return;
-                                            }
-                                            if (hasChild) {
+                        {isMobileMenuOpen && (
+                            <div css={SS.mobilePanel}>
+                                <div css={SS.mobilePanelHeader}>
+                                    {activePath.length > 1 ? (
+                                        <button
+                                            type="button"
+                                            css={SS.mobileBackButton}
+                                            onClick={() => {
                                                 dispatch(
-                                                    pushMobileTopMenuPath(index)
+                                                    popMobileTopMenuPath()
                                                 );
-                                                return;
-                                            }
-                                            runMenuItem(item);
-                                        }
-                                    }}
+                                            }}
+                                            aria-label="Go back"
+                                        >
+                                            <ArrowBackIcon
+                                                css={SS.mobileBackIcon}
+                                            />
+                                            <span>{currentLabel}</span>
+                                        </button>
+                                    ) : (
+                                        <h3 css={SS.mobilePanelTitle}>
+                                            {currentLabel}
+                                        </h3>
+                                    )}
+                                </div>
+
+                                <ul
+                                    id="mobile-top-menu"
+                                    role="menu"
+                                    css={SS.mobilePanelList}
                                 >
-                                    {item.checked && (
-                                        <SelectedIcon css={SS.selectedIcon} />
-                                    )}
-                                    <p css={SS.paraLabel}>{item.label}</p>
-                                    {hasChild && (
-                                        <NestedMenuIcon
-                                            css={SS.nestedMenuIcon}
-                                        />
-                                    )}
-                                </li>
-                            );
-                        })}
-                    </ul>
+                                    {currentItems.map((item, index) => {
+                                        if (item.seperator) {
+                                            return (
+                                                <hr key={index} css={hrCss} />
+                                            );
+                                        }
+
+                                        const hasChild = !!item.submenu;
+
+                                        return (
+                                            <li
+                                                key={index}
+                                                role="menuitem"
+                                                tabIndex={0}
+                                                css={
+                                                    item.disabled
+                                                        ? SS.listItemDisabled
+                                                        : SS.listItem
+                                                }
+                                                onClick={(event) => {
+                                                    if (item.disabled) {
+                                                        event.preventDefault();
+                                                        return;
+                                                    }
+
+                                                    if (hasChild) {
+                                                        dispatch(
+                                                            pushMobileTopMenuPath(
+                                                                index
+                                                            )
+                                                        );
+                                                        return;
+                                                    }
+
+                                                    runMenuItem(item, event);
+                                                }}
+                                                onKeyDown={(event) => {
+                                                    if (
+                                                        event.key === "Enter" ||
+                                                        event.key === " "
+                                                    ) {
+                                                        event.preventDefault();
+                                                        if (item.disabled) {
+                                                            return;
+                                                        }
+                                                        if (hasChild) {
+                                                            dispatch(
+                                                                pushMobileTopMenuPath(
+                                                                    index
+                                                                )
+                                                            );
+                                                            return;
+                                                        }
+                                                        runMenuItem(item);
+                                                    }
+                                                }}
+                                            >
+                                                {item.checked && (
+                                                    <SelectedIcon
+                                                        css={SS.selectedIcon}
+                                                    />
+                                                )}
+                                                <p css={SS.paraLabel}>
+                                                    {item.label}
+                                                </p>
+                                                {hasChild && (
+                                                    <NestedMenuIcon
+                                                        css={SS.nestedMenuIcon}
+                                                    />
+                                                )}
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
                 )}
             </>
         );
@@ -662,9 +804,9 @@ export function MenuBar() {
 
     return (
         <>
-            <ul css={SS.root} ref={menuRootRef}>
+            <div css={SS.root} ref={menuRootRef}>
                 {mobileView ? mobileColumns() : columns(openPath)}
-            </ul>
+            </div>
         </>
     );
 }

--- a/src/components/menu-bar/menu-bar.tsx
+++ b/src/components/menu-bar/menu-bar.tsx
@@ -1,8 +1,16 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState
+} from "react";
 import { RootState, useDispatch, useSelector } from "@root/store";
 import { useLocalStorage } from "react-use-storage";
 import SelectedIcon from "@mui/icons-material/DoneSharp";
 import NestedMenuIcon from "@mui/icons-material/ArrowRightSharp";
+import MenuIcon from "@mui/icons-material/Menu";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import * as SS from "./styles";
 import { hr as hrCss } from "@styles/_common";
 import { MenuItemDef } from "./types";
@@ -20,40 +28,44 @@ import { renderToDisk } from "@comp/csound/actions";
 import { selectCsoundStatus } from "@comp/csound/selectors";
 import { selectIsOwner } from "@comp/project-editor/selectors";
 import { changeTheme } from "@comp/themes/action";
-import {
-    append,
-    equals,
-    isEmpty,
-    path,
-    pathOr,
-    propOr,
-    reduce,
-    slice
-} from "ramda";
+import { equals, isEmpty } from "ramda";
 import { showKeyboardShortcuts } from "@comp/site-documents/actions";
 import { openBottomTab } from "@comp/bottom-tabs/actions";
+import { isMobile } from "@root/utils";
+import {
+    closeMobileTopMenu,
+    popMobileTopMenuPath,
+    pushMobileTopMenuPath,
+    resetMobileTopMenuPath,
+    toggleMobileTopMenu
+} from "@comp/menu-ui/actions";
+import {
+    selectIsMobileTopMenuOpen,
+    selectMobileTopMenuPath
+} from "@comp/menu-ui/selectors";
 
 export function MenuBar() {
     const setConsole = useSetConsole();
     const menuRootRef = useRef<HTMLUListElement | null>(null);
+    const firstMobileItemRef = useRef<HTMLLIElement | null>(null);
 
-    const activeProjectUid: string = useSelector(
-        pathOr("", ["ProjectsReducer", "activeProjectUid"])
+    const activeProjectUid = useSelector(
+        (store: RootState) => store.ProjectsReducer.activeProjectUid || ""
     );
 
     const dispatch = useDispatch();
     const isOwner = useSelector(selectIsOwner);
     const csoundStatus = useSelector(selectCsoundStatus);
-    const keyBindings: BindingsMap | undefined = useSelector(
-        path(["HotKeysReducer", "bindings"])
+    const keyBindings = useSelector(
+        (store: RootState) => store.HotKeysReducer.bindings
     );
 
-    const selectedThemeName: string | undefined = useSelector(
-        path(["ThemeReducer", "selectedThemeName"])
+    const selectedThemeName = useSelector(
+        (store: RootState) => store.ThemeReducer.selectedThemeName
     );
 
-    const isManualOpen: boolean = useSelector((store) =>
-        path(["ProjectEditorReducer", "manualVisible"], store)
+    const isManualOpen = useSelector(
+        (store: RootState) => store.ProjectEditorReducer.manualVisible
     );
 
     const isConsoleVisible = useSelector((store: RootState) =>
@@ -72,226 +84,236 @@ export function MenuBar() {
         store.BottomTabsReducer.openTabs.includes("piano")
     );
 
+    const isMobileMenuOpen = useSelector(selectIsMobileTopMenuOpen);
+    const mobilePath = useSelector(selectMobileTopMenuPath);
+
     const [isSabEnabled, setIsSabEnabled] = useLocalStorage("sab", "false");
+    const [openPath, setOpenPath] = useState<number[]>([]);
+    const mobileView = isMobile();
 
-    const menuBarItems: MenuItemDef[] = [
-        {
-            label: "File",
-            submenu: [
-                {
-                    label: "New File…",
-                    hotKey: "new_document",
-                    disabled: !isOwner
-                },
-                {
-                    label: "Add File(s)…",
-                    hotKey: "add_file",
-                    disabled: !isOwner
-                },
-                {
-                    label: "Save Document",
-                    hotKey: "save_document",
-                    disabled: !isOwner
-                },
-                {
-                    label: "Save All",
-                    hotKey: "save_all_documents",
-                    disabled: !isOwner
-                },
-                {
-                    seperator: true
-                },
-                {
-                    label: "Render to Disk",
-                    callback: () => dispatch(renderToDisk(setConsole))
-                },
-                {
-                    label: "Export Project (.zip)",
-                    callback: () => dispatch(exportProject())
-                },
-                {
-                    seperator: true
-                },
-                {
-                    label: isOwner ? "Save and Close" : "Close",
-                    hotKey: "save_and_close"
-                }
-            ]
-        },
-        {
-            label: "Edit",
-            submenu: [
-                { label: "Undo", hotKey: "undo" },
-                { label: "Redo", hotKey: "redo" },
-                { label: "Search", hotKey: "find_simple" },
-                {
-                    label: "Theme",
-                    submenu: [
-                        {
-                            label: "Default",
-                            callback: () => dispatch(changeTheme("default")),
-                            checked: selectedThemeName === "default"
-                        },
-                        {
-                            label: "GitHub Modern",
-                            callback: () => dispatch(changeTheme("github")),
-                            checked: selectedThemeName === "github"
-                        },
-                        {
-                            label: "GitHub Light",
-                            callback: () =>
-                                dispatch(changeTheme("github-light")),
-                            checked: selectedThemeName === "github-light"
-                        },
-                        {
-                            label: "Dracula",
-                            callback: () => dispatch(changeTheme("dracula")),
-                            checked: selectedThemeName === "dracula"
-                        },
-                        {
-                            label: "Nord",
-                            callback: () => dispatch(changeTheme("nord")),
-                            checked: selectedThemeName === "nord"
-                        },
-                        {
-                            label: "Solarized Dark",
-                            callback: () =>
-                                dispatch(changeTheme("solarized-dark")),
-                            checked: selectedThemeName === "solarized-dark"
+    const menuBarItems: MenuItemDef[] = useMemo(
+        () => [
+            {
+                label: "File",
+                submenu: [
+                    {
+                        label: "New File…",
+                        hotKey: "new_document",
+                        disabled: !isOwner
+                    },
+                    {
+                        label: "Add File(s)…",
+                        hotKey: "add_file",
+                        disabled: !isOwner
+                    },
+                    {
+                        label: "Save Document",
+                        hotKey: "save_document",
+                        disabled: !isOwner
+                    },
+                    {
+                        label: "Save All",
+                        hotKey: "save_all_documents",
+                        disabled: !isOwner
+                    },
+                    {
+                        seperator: true
+                    },
+                    {
+                        label: "Render to Disk",
+                        callback: () => dispatch(renderToDisk(setConsole))
+                    },
+                    {
+                        label: "Export Project (.zip)",
+                        callback: () => dispatch(exportProject())
+                    },
+                    {
+                        seperator: true
+                    },
+                    {
+                        label: isOwner ? "Save and Close" : "Close",
+                        hotKey: "save_and_close"
+                    }
+                ]
+            },
+            {
+                label: "Edit",
+                submenu: [
+                    { label: "Undo", hotKey: "undo" },
+                    { label: "Redo", hotKey: "redo" },
+                    { label: "Search", hotKey: "find_simple" },
+                    {
+                        label: "Theme",
+                        submenu: [
+                            {
+                                label: "Default",
+                                callback: () =>
+                                    dispatch(changeTheme("default")),
+                                checked: selectedThemeName === "default"
+                            },
+                            {
+                                label: "GitHub Modern",
+                                callback: () => dispatch(changeTheme("github")),
+                                checked: selectedThemeName === "github"
+                            },
+                            {
+                                label: "GitHub Light",
+                                callback: () =>
+                                    dispatch(changeTheme("github-light")),
+                                checked: selectedThemeName === "github-light"
+                            },
+                            {
+                                label: "Dracula",
+                                callback: () =>
+                                    dispatch(changeTheme("dracula")),
+                                checked: selectedThemeName === "dracula"
+                            },
+                            {
+                                label: "Nord",
+                                callback: () => dispatch(changeTheme("nord")),
+                                checked: selectedThemeName === "nord"
+                            },
+                            {
+                                label: "Solarized Dark",
+                                callback: () =>
+                                    dispatch(changeTheme("solarized-dark")),
+                                checked: selectedThemeName === "solarized-dark"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                label: "Project",
+                submenu: [
+                    {
+                        label:
+                            csoundStatus === "paused" ? "Resume" : "Run/Play",
+                        hotKey: "run_project",
+                        disabled: csoundStatus === "playing"
+                    },
+                    {
+                        label: "Stop",
+                        hotKey: "stop_playback",
+                        disabled:
+                            csoundStatus !== "playing" &&
+                            csoundStatus !== "paused"
+                    },
+                    {
+                        label: "Pause",
+                        hotKey: "pause_playback",
+                        disabled: csoundStatus !== "playing"
+                    },
+                    {
+                        seperator: true
+                    },
+                    {
+                        label: "Configure Targets",
+                        callback: () => dispatch(showTargetsConfigDialog()),
+                        disabled: !isOwner
+                    }
+                ]
+            },
+            {
+                label: "View",
+                submenu: [
+                    {
+                        label: "Csound Manual",
+                        callback: () => dispatch(toggleManualPanel()),
+                        checked: isManualOpen
+                    },
+                    {
+                        label: "File Tree",
+                        callback: () =>
+                            dispatch(setFileTreePanelOpen(!isFileTreeVisible)),
+                        checked: isFileTreeVisible
+                    },
+                    {
+                        label: "Console",
+                        callback: () => dispatch(openBottomTab("console")),
+                        checked: isConsoleVisible
+                    },
+                    {
+                        label: "Spectral Analyzer",
+                        callback: () =>
+                            dispatch(openBottomTab("spectralAnalyzer")),
+                        checked: isSpectralAnalyzerVisible
+                    },
+                    {
+                        label: "Virtual Midi Keyboard",
+                        callback: () => dispatch(openBottomTab("piano")),
+                        checked: isMidiPianoVisible
+                    }
+                ]
+            },
+            {
+                label: "I/O",
+                submenu: [
+                    {
+                        label: "Enable SharedArrayBuffer",
+                        checked: isSabEnabled === "true",
+                        callback: () => {
+                            setIsSabEnabled(
+                                isSabEnabled === "true" ? "false" : "true"
+                            );
                         }
-                    ]
-                }
-            ]
-        },
-        {
-            label: "Project",
-            submenu: [
-                {
-                    label: csoundStatus === "paused" ? "Resume" : "Run/Play",
-                    hotKey: "run_project",
-                    disabled: csoundStatus === "playing"
-                },
-                {
-                    label: "Stop",
-                    hotKey: "stop_playback",
-                    disabled:
-                        csoundStatus !== "playing" && csoundStatus !== "paused"
-                },
-                {
-                    label: "Pause",
-                    hotKey: "pause_playback",
-                    disabled: csoundStatus !== "playing"
-                },
-                {
-                    seperator: true
-                },
-                {
-                    label: "Configure Targets",
-                    callback: () => dispatch(showTargetsConfigDialog()),
-                    disabled: !isOwner
-                }
-            ]
-        },
-        {
-            label: "View",
-            submenu: [
-                {
-                    label: "Csound Manual",
-                    callback: () => dispatch(toggleManualPanel()),
-                    checked: isManualOpen
-                },
-                {
-                    label: "File Tree",
-                    callback: () =>
-                        dispatch(setFileTreePanelOpen(!isFileTreeVisible)),
-                    checked: isFileTreeVisible
-                },
-                {
-                    label: "Console",
-                    callback: () => dispatch(openBottomTab("console")),
-                    checked: isConsoleVisible
-                },
-                {
-                    label: "Spectral Analyzer",
-                    callback: () => dispatch(openBottomTab("spectralAnalyzer")),
-                    checked: isSpectralAnalyzerVisible
-                },
-                {
-                    label: "Virtual Midi Keyboard",
-                    callback: () => dispatch(openBottomTab("piano")),
-                    checked: isMidiPianoVisible
-                }
-            ]
-        },
-        {
-            label: "I/O",
-            submenu: [
-                // {
-                //     label: "Refresh MIDI Input",
-                //     callback: () => {
-                //         dispatch(enableMidiInput());
-                //     }
-                // },
-                // {
-                //     label: "Refresh Audio Input",
-                //     callback: () => {
-                //         dispatch(enableAudioInput());
-                //     }
-                // },
-                // {
-                //     seperator: true
-                // },
-                {
-                    label: "Enable SharedArrayBuffer",
-                    checked: isSabEnabled === "true",
-                    callback: () => {
-                        setIsSabEnabled(
-                            isSabEnabled === "true" ? "false" : "true"
-                        );
                     }
-                }
-            ]
-        },
-        {
-            label: "Help",
-            submenu: [
-                {
-                    label: "Csound Manual (External)",
-                    callback: () => {
-                        window.open("https://csound.com/docs/manual", "_blank");
+                ]
+            },
+            {
+                label: "Help",
+                submenu: [
+                    {
+                        label: "Csound Manual (External)",
+                        callback: () => {
+                            window.open(
+                                "https://csound.com/docs/manual",
+                                "_blank"
+                            );
+                        }
+                    },
+                    {
+                        label: "Csound FLOSS Manual",
+                        callback: () => {
+                            window.open(
+                                "https://flossmanual.csound.com/",
+                                "_blank"
+                            );
+                        }
+                    },
+                    {
+                        seperator: true
+                    },
+                    {
+                        label: "Web-IDE Documentation",
+                        callback: () => {
+                            window.open("/documentation", "_blank");
+                        }
+                    },
+                    {
+                        seperator: true
+                    },
+                    {
+                        label: "Show Keyboard Shortcuts",
+                        callback: () => dispatch(showKeyboardShortcuts())
                     }
-                },
-                {
-                    label: "Csound FLOSS Manual",
-                    callback: () => {
-                        window.open(
-                            "https://flossmanual.csound.com/",
-                            "_blank"
-                        );
-                    }
-                },
-                {
-                    seperator: true
-                },
-                {
-                    label: "Web-IDE Documentation",
-                    callback: () => {
-                        window.open("/documentation", "_blank");
-                    }
-                },
-                {
-                    seperator: true
-                },
-                {
-                    label: "Show Keyboard Shortcuts",
-                    callback: () => dispatch(showKeyboardShortcuts())
-                }
-            ]
-        }
-    ];
-
-    const [openPath, setOpenPath]: [number[], (p: number[]) => any] = useState(
-        [] as number[]
+                ]
+            }
+        ],
+        [
+            csoundStatus,
+            dispatch,
+            isConsoleVisible,
+            isFileTreeVisible,
+            isManualOpen,
+            isMidiPianoVisible,
+            isOwner,
+            isSabEnabled,
+            isSpectralAnalyzerVisible,
+            selectedThemeName,
+            setConsole,
+            setIsSabEnabled
+        ]
     );
 
     useEffect(() => {
@@ -305,6 +327,7 @@ export function MenuBar() {
                 !menuRootRef.current.contains(targetNode)
             ) {
                 setOpenPath([]);
+                dispatch(closeMobileTopMenu());
             }
         };
 
@@ -323,168 +346,324 @@ export function MenuBar() {
                 true
             );
         };
-    }, []);
+    }, [dispatch]);
+
+    useEffect(() => {
+        const closeOnEscape = (event: KeyboardEvent) => {
+            if (event.key !== "Escape") {
+                return;
+            }
+            setOpenPath([]);
+            dispatch(closeMobileTopMenu());
+        };
+
+        window.addEventListener("keydown", closeOnEscape);
+
+        return () => {
+            window.removeEventListener("keydown", closeOnEscape);
+        };
+    }, [dispatch]);
+
+    useEffect(() => {
+        if (!isMobileMenuOpen) {
+            return;
+        }
+
+        firstMobileItemRef.current?.focus();
+    }, [isMobileMenuOpen, mobilePath]);
+
+    const runMenuItem = useCallback(
+        (item: MenuItemDef, event?: React.MouseEvent) => {
+            if (item.disabled) {
+                event?.preventDefault();
+                return;
+            }
+
+            if (item.hotKey) {
+                invokeHotKeyCallback(item.hotKey);
+            } else {
+                item.callback && item.callback();
+                event?.preventDefault();
+            }
+
+            if (mobileView) {
+                dispatch(closeMobileTopMenu());
+            }
+        },
+        [dispatch, mobileView]
+    );
+
+    const getItemsAtPath = useCallback(
+        (items: MenuItemDef[], nestingPath: number[]): MenuItemDef[] => {
+            let currentItems = items;
+            for (const pathIndex of nestingPath) {
+                currentItems = currentItems[pathIndex]?.submenu || [];
+            }
+            return currentItems;
+        },
+        []
+    );
+
+    const isPathOpen = (
+        targetPath: number[],
+        openedPath: number[]
+    ): boolean => {
+        if (targetPath.length > openedPath.length) {
+            return false;
+        }
+        return targetPath.every((value, index) => value === openedPath[index]);
+    };
 
     const reduceRow = (
         items: MenuItemDef[],
-        openPath: number[],
+        openedPath: number[],
         rowNesting: number[]
-    ) =>
-        reduce(
-            (accumulator: React.ReactNode[], item: MenuItemDef) => {
-                const index = accumulator.length;
-                const thisRowNesting = append(index, rowNesting);
-                const hasChild: boolean = item.submenu !== undefined;
+    ): React.ReactNode[] =>
+        items.map((item, index) => {
+            const thisRowNesting = [...rowNesting, index];
+            const hasChild: boolean = item.submenu !== undefined;
 
-                if (item.seperator) {
-                    accumulator.push(<hr key={index} css={hrCss} />);
-                } else {
-                    accumulator.push(
-                        <div
-                            key={index}
-                            onClick={(event) => {
-                                if (item.disabled) {
-                                    event.preventDefault();
-                                    return;
-                                }
-                                if (item.hotKey) {
-                                    invokeHotKeyCallback(item.hotKey);
-                                } else {
-                                    item.callback && item.callback();
-                                    event.preventDefault();
-                                }
-                            }}
-                            css={hasChild && SS.nestedWrapper}
-                            onMouseOver={() => {
-                                setOpenPath(thisRowNesting);
-                            }}
-                        >
-                            {hasChild &&
-                                equals(
-                                    thisRowNesting,
-                                    (slice as any)(
-                                        0,
-                                        thisRowNesting.length,
-                                        openPath
-                                    )
-                                ) && (
-                                    <ul
-                                        css={SS.dropdownListNested}
-                                        style={{
-                                            zIndex: thisRowNesting.length
-                                        }}
-                                        onMouseOver={(event) => {
-                                            thisRowNesting.length >
-                                                openPath.length &&
-                                                setOpenPath(
-                                                    append(
-                                                        0,
-                                                        (slice as any)(
-                                                            0,
-                                                            thisRowNesting.length,
-                                                            openPath
-                                                        )
-                                                    )
-                                                );
-                                            event.stopPropagation();
-                                        }}
-                                    >
-                                        {reduceRow(
-                                            item.submenu || [],
-                                            openPath,
-                                            thisRowNesting
-                                        )}
-                                    </ul>
-                                )}
-
-                            <li
-                                css={
-                                    item.disabled
-                                        ? SS.listItemDisabled
-                                        : SS.listItem
-                                }
-                            >
-                                {item.checked && (
-                                    <SelectedIcon css={SS.selectedIcon} />
-                                )}
-                                <p css={SS.paraLabel}>{item.label}</p>
-                                {item.hotKey &&
-                                    keyBindings &&
-                                    ((keyBindings as any)[
-                                        item.hotKey
-                                    ] as any) && (
-                                        <i css={SS.paraLabel}>
-                                            {humanizeKeySequence(
-                                                propOr(
-                                                    "",
-                                                    item.hotKey,
-                                                    keyBindings
-                                                )
-                                            )}
-                                        </i>
-                                    )}
-                                {hasChild && (
-                                    <NestedMenuIcon css={SS.nestedMenuIcon} />
-                                )}
-                            </li>
-                        </div>
-                    );
-                }
-                return accumulator;
-            },
-            [] as React.ReactNode[],
-            items
-        );
-
-    const columns = (openPath: number[]) =>
-        reduce(
-            (accumulator: React.ReactNode[], item: MenuItemDef) => {
-                const index = accumulator.length;
-                // const openPath = openPath;
-                const anyColIsOpen = !isEmpty(openPath);
-                const thisColIsOpen =
-                    !isEmpty(openPath) && equals(openPath[0], index);
-                const row = (
-                    <ul
-                        style={{ display: thisColIsOpen ? "inline" : "none" }}
-                        css={SS.dropdownList}
-                    >
-                        {!isEmpty(openPath) &&
-                            !isEmpty(item.submenu) &&
-                            reduceRow(item.submenu || [], openPath, [index])}
-                    </ul>
+            if (item.seperator) {
+                return (
+                    <hr
+                        key={`separator-${thisRowNesting.join("-")}`}
+                        css={hrCss}
+                    />
                 );
-                accumulator.push(
+            } else {
+                const hotKeySequence = item.hotKey
+                    ? keyBindings?.[item.hotKey]
+                    : undefined;
+                const hotKeyLabel =
+                    typeof hotKeySequence === "string"
+                        ? humanizeKeySequence(hotKeySequence)
+                        : "";
+
+                return (
                     <div
-                        css={SS.dropdownButtonWrapper}
-                        key={accumulator.length}
-                        onClick={() => {
-                            thisColIsOpen
-                                ? setOpenPath([])
-                                : setOpenPath([index]);
+                        key={thisRowNesting.join("-")}
+                        onClick={(event) => {
+                            runMenuItem(item, event);
+                        }}
+                        css={hasChild && SS.nestedWrapper}
+                        onMouseOver={() => {
+                            setOpenPath(thisRowNesting);
                         }}
                     >
-                        <div
-                            css={SS.dropdownButton}
-                            onMouseOver={() =>
-                                anyColIsOpen && setOpenPath([index])
+                        {hasChild && isPathOpen(thisRowNesting, openedPath) && (
+                            <ul
+                                role="menu"
+                                css={SS.dropdownListNested}
+                                style={{
+                                    zIndex: thisRowNesting.length
+                                }}
+                                onMouseOver={(event) => {
+                                    thisRowNesting.length > openedPath.length &&
+                                        setOpenPath([
+                                            ...openedPath.slice(
+                                                0,
+                                                thisRowNesting.length
+                                            ),
+                                            0
+                                        ]);
+                                    event.stopPropagation();
+                                }}
+                            >
+                                {reduceRow(
+                                    item.submenu || [],
+                                    openedPath,
+                                    thisRowNesting
+                                )}
+                            </ul>
+                        )}
+
+                        <li
+                            role="menuitem"
+                            tabIndex={0}
+                            css={
+                                item.disabled
+                                    ? SS.listItemDisabled
+                                    : SS.listItem
                             }
                         >
-                            <span>{item.label}</span>
-                        </div>
-                        {row}
+                            {item.checked && (
+                                <SelectedIcon css={SS.selectedIcon} />
+                            )}
+                            <p css={SS.paraLabel}>{item.label}</p>
+                            {hotKeyLabel && (
+                                <i css={SS.paraLabel}>{hotKeyLabel}</i>
+                            )}
+                            {hasChild && (
+                                <NestedMenuIcon css={SS.nestedMenuIcon} />
+                            )}
+                        </li>
                     </div>
                 );
-                return accumulator;
-            },
-            [] as React.ReactNode[],
-            menuBarItems
+            }
+        });
+
+    const mobileColumns = () => {
+        const currentItems = getItemsAtPath(menuBarItems, mobilePath);
+        const currentLabel =
+            mobilePath.length > 0
+                ? getItemsAtPath(menuBarItems, mobilePath.slice(0, -1))[
+                      mobilePath[mobilePath.length - 1]
+                  ]?.label
+                : "Menu";
+
+        return (
+            <>
+                <button
+                    type="button"
+                    css={SS.mobileMenuButton}
+                    aria-label="Toggle menu"
+                    aria-haspopup="menu"
+                    aria-controls="mobile-top-menu"
+                    aria-expanded={isMobileMenuOpen}
+                    onClick={() => {
+                        dispatch(toggleMobileTopMenu());
+                        if (isMobileMenuOpen) {
+                            dispatch(resetMobileTopMenuPath());
+                        }
+                    }}
+                >
+                    <MenuIcon css={SS.mobileMenuIcon} />
+                    <span>Menu</span>
+                </button>
+                {isMobileMenuOpen && (
+                    <ul
+                        id="mobile-top-menu"
+                        role="menu"
+                        css={SS.mobileDropdownList}
+                    >
+                        {mobilePath.length > 0 && (
+                            <li
+                                ref={firstMobileItemRef}
+                                role="menuitem"
+                                tabIndex={0}
+                                css={SS.mobileBackItem}
+                                onClick={() => {
+                                    dispatch(popMobileTopMenuPath());
+                                }}
+                            >
+                                <ArrowBackIcon css={SS.mobileBackIcon} />
+                                <span>{currentLabel}</span>
+                            </li>
+                        )}
+
+                        {currentItems.map((item, index) => {
+                            if (item.seperator) {
+                                return <hr key={index} css={hrCss} />;
+                            }
+
+                            const hasChild = !!item.submenu;
+
+                            return (
+                                <li
+                                    key={index}
+                                    ref={
+                                        mobilePath.length === 0 && index === 0
+                                            ? firstMobileItemRef
+                                            : null
+                                    }
+                                    role="menuitem"
+                                    tabIndex={0}
+                                    css={
+                                        item.disabled
+                                            ? SS.listItemDisabled
+                                            : SS.listItem
+                                    }
+                                    onClick={(event) => {
+                                        if (item.disabled) {
+                                            event.preventDefault();
+                                            return;
+                                        }
+
+                                        if (hasChild) {
+                                            dispatch(
+                                                pushMobileTopMenuPath(index)
+                                            );
+                                            return;
+                                        }
+
+                                        runMenuItem(item, event);
+                                    }}
+                                    onKeyDown={(event) => {
+                                        if (
+                                            event.key === "Enter" ||
+                                            event.key === " "
+                                        ) {
+                                            event.preventDefault();
+                                            if (item.disabled) {
+                                                return;
+                                            }
+                                            if (hasChild) {
+                                                dispatch(
+                                                    pushMobileTopMenuPath(index)
+                                                );
+                                                return;
+                                            }
+                                            runMenuItem(item);
+                                        }
+                                    }}
+                                >
+                                    {item.checked && (
+                                        <SelectedIcon css={SS.selectedIcon} />
+                                    )}
+                                    <p css={SS.paraLabel}>{item.label}</p>
+                                    {hasChild && (
+                                        <NestedMenuIcon
+                                            css={SS.nestedMenuIcon}
+                                        />
+                                    )}
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </>
         );
+    };
+
+    const columns = (openPath: number[]) =>
+        menuBarItems.map((item, index) => {
+            const anyColIsOpen = !isEmpty(openPath);
+            const thisColIsOpen =
+                !isEmpty(openPath) && equals(openPath[0], index);
+            const row = (
+                <ul
+                    role="menu"
+                    style={{ display: thisColIsOpen ? "inline" : "none" }}
+                    css={SS.dropdownList}
+                >
+                    {!isEmpty(openPath) &&
+                        !isEmpty(item.submenu) &&
+                        reduceRow(item.submenu || [], openPath, [index])}
+                </ul>
+            );
+            return (
+                <div
+                    css={SS.dropdownButtonWrapper}
+                    key={index}
+                    onClick={() => {
+                        thisColIsOpen ? setOpenPath([]) : setOpenPath([index]);
+                    }}
+                >
+                    <div
+                        css={SS.dropdownButton}
+                        onMouseOver={() => anyColIsOpen && setOpenPath([index])}
+                    >
+                        <span>{item.label}</span>
+                    </div>
+                    {row}
+                </div>
+            );
+        });
 
     return (
         <>
             <ul css={SS.root} ref={menuRootRef}>
-                {columns(openPath)}
+                {mobileView ? mobileColumns() : columns(openPath)}
             </ul>
         </>
     );

--- a/src/components/menu-bar/styles.ts
+++ b/src/components/menu-bar/styles.ts
@@ -17,6 +17,68 @@ export const root = (theme: Theme): SerializedStyles => css`
     z-index: 1;
 `;
 
+export const mobileMenuButton = (theme: Theme): SerializedStyles => css`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: 2px solid ${theme.line};
+    border-radius: 6px;
+    padding: 6px 10px;
+    margin: 2px;
+    cursor: pointer;
+    color: ${theme.headerTextColor};
+    ${shadow}
+    transition:
+        transform 0.18s ease,
+        background-color 0.18s ease,
+        box-shadow 0.18s ease;
+
+    &:hover {
+        background-color: ${theme.buttonBackgroundHover};
+        transform: translateY(-1px);
+    }
+
+    &:focus-visible {
+        outline: 2px solid ${theme.highlightBackground};
+        outline-offset: 2px;
+    }
+
+    span {
+        font-size: 14px;
+        font-weight: 600;
+        letter-spacing: 1px;
+        line-height: 1;
+    }
+`;
+
+export const mobileMenuIcon = (theme: Theme): SerializedStyles => css`
+    color: ${theme.headerTextColor};
+`;
+
+export const mobileDropdownList = (theme: Theme): SerializedStyles => css`
+    ${dropdownList(theme)}
+    position: fixed;
+    top: 56px;
+    left: 8px;
+    right: 8px;
+    width: auto;
+    max-height: calc(100vh - 72px);
+    overflow-y: auto;
+    margin-top: 0;
+`;
+
+export const mobileBackItem = (theme: Theme): SerializedStyles => css`
+    ${listItem(theme)}
+    border-bottom: 1px solid ${theme.line};
+    align-items: center;
+`;
+
+export const mobileBackIcon = (theme: Theme): SerializedStyles => css`
+    color: ${theme.headerTextColor};
+    margin-left: 6px;
+`;
+
 export const selectedIcon = (theme: Theme): SerializedStyles => css`
     position: absolute;
     fill: ${theme.headerTextColor};
@@ -45,17 +107,25 @@ export const dropdownButtonWrapper = css`
 `;
 
 export const dropdownButton = (theme: Theme): SerializedStyles => css`
-    $[shadow];
+    ${shadow}
     z-index: 2;
     display: inline;
     border: 2px solid ${theme.line};
     border-radius: 6px;
     padding: 4px 8px;
-   margin: 2px;
+    margin: 2px;
+    transition:
+        background-color 0.16s ease,
+        transform 0.16s ease;
     &:hover {
         cursor: pointer;
         background-color: ${theme.buttonBackgroundHover};
         z-index: 3;
+        transform: translateY(-1px);
+    }
+    &:focus-visible {
+        outline: 2px solid ${theme.highlightBackground};
+        outline-offset: 2px;
     }
     & > span {
         font-size: 14px;
@@ -74,13 +144,24 @@ export const dropdownList = (theme: Theme): SerializedStyles => css`
     position: absolute;
     list-style: none !important;
     padding: 0;
-    animation: fadeIn 0.01s linear;
+    animation: menuSlideFadeIn 0.16s ease;
     outline: 0;
     margin: 0;
     margin-top: 24px;
     left: 0;
     top: 5px;
     ${shadow}
+
+    @keyframes menuSlideFadeIn {
+        from {
+            opacity: 0;
+            transform: translateY(-4px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
 `;
 
 export const dropdownListNested = (theme: Theme): SerializedStyles => css`
@@ -108,6 +189,11 @@ export const listItem = (theme: Theme): SerializedStyles => css`
         background-color: ${theme.buttonBackgroundHover};
         border-radius: 2px;
         ${shadow};
+    }
+    &:focus-visible {
+        outline: 2px solid ${theme.highlightBackground};
+        outline-offset: -2px;
+        border-radius: 2px;
     }
     & > p,
     & span {

--- a/src/components/menu-bar/styles.ts
+++ b/src/components/menu-bar/styles.ts
@@ -1,5 +1,8 @@
 import { css, SerializedStyles, Theme } from "@emotion/react";
 import { shadow } from "@styles/_common";
+import { headerHeight } from "@styles/constants";
+
+const mobileBottomInset = 56;
 
 export const root = (theme: Theme): SerializedStyles => css`
     color: ${theme.headerTextColor};
@@ -15,57 +18,178 @@ export const root = (theme: Theme): SerializedStyles => css`
     user-select: none;
     margin-left: 12px;
     z-index: 1;
+
+    @media (max-width: 900px) {
+        margin-left: 6px;
+    }
 `;
 
-export const mobileMenuButton = (theme: Theme): SerializedStyles => css`
+export const mobileTopTriggerButton =
+    (isActive: boolean) =>
+    (theme: Theme): SerializedStyles => css`
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        margin: 0 8px 0 0;
+        border: 2px solid ${theme.line};
+        border-radius: 8px;
+        color: ${theme.headerTextColor};
+        background: ${isActive ? theme.buttonBackgroundHover : "transparent"};
+        cursor: pointer;
+        ${shadow}
+
+        &:hover {
+            background: ${theme.buttonBackgroundHover};
+        }
+
+        &:focus-visible {
+            outline: 2px solid ${theme.highlightBackground};
+            outline-offset: 2px;
+        }
+    `;
+
+export const mobileDock = css`
+    position: fixed;
+    top: ${headerHeight + 8}px;
+    left: 8px;
+    right: 8px;
+    bottom: ${mobileBottomInset}px;
+    z-index: 20000;
+    display: flex;
+    align-items: stretch;
+    gap: 10px;
+`;
+
+export const mobileDockBackdrop = css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 19999;
+    background: rgba(0, 0, 0, 0.4);
+`;
+
+export const mobileRail = (theme: Theme): SerializedStyles => css`
+    display: flex;
+    flex-direction: column;
+    width: 88px;
+    min-width: 88px;
+    border-right: 1px solid ${theme.line};
+    background: ${theme.buttonBackground};
+    border-radius: 12px;
+    border: 1px solid ${theme.line};
+    min-height: 0;
+`;
+
+export const mobileRailList = css`
+    list-style: none;
+    margin: 0;
+    padding: 4px;
+    overflow-y: auto;
+    min-height: 0;
+    flex: 1;
+`;
+
+export const mobileRailButton =
+    (isActive: boolean) =>
+    (theme: Theme): SerializedStyles => css`
+        width: 100%;
+        border: 0;
+        border-radius: 10px;
+        margin-bottom: 6px;
+        padding: 8px 6px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        color: ${theme.headerTextColor};
+        background: ${isActive ? theme.buttonBackgroundHover : "transparent"};
+        cursor: pointer;
+
+        &:hover {
+            background: ${theme.buttonBackgroundHover};
+        }
+
+        &:focus-visible {
+            outline: 2px solid ${theme.highlightBackground};
+            outline-offset: -2px;
+        }
+    `;
+
+export const mobileRailIcon = css`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+        font-size: 18px;
+    }
+`;
+
+export const mobileRailText = css`
+    font-size: 11px;
+    line-height: 1;
+    text-align: center;
+`;
+
+export const mobilePanel = (theme: Theme): SerializedStyles => css`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    width: auto;
+    max-width: 100%;
+    border-radius: 12px;
+    border: 2px solid ${theme.line};
+    background: ${theme.headerBackground};
+    overflow: hidden;
+    ${shadow}
+`;
+
+export const mobilePanelHeader = (theme: Theme): SerializedStyles => css`
+    min-height: 52px;
+    padding: 6px 8px;
+    border-bottom: 1px solid ${theme.line};
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+`;
+
+export const mobileBackButton = (theme: Theme): SerializedStyles => css`
+    border: 0;
+    background: transparent;
+    color: ${theme.headerTextColor};
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: transparent;
-    border: 2px solid ${theme.line};
-    border-radius: 6px;
-    padding: 6px 10px;
-    margin: 2px;
+    padding: 6px;
+    border-radius: 8px;
     cursor: pointer;
-    color: ${theme.headerTextColor};
-    ${shadow}
-    transition:
-        transform 0.18s ease,
-        background-color 0.18s ease,
-        box-shadow 0.18s ease;
 
     &:hover {
-        background-color: ${theme.buttonBackgroundHover};
-        transform: translateY(-1px);
-    }
-
-    &:focus-visible {
-        outline: 2px solid ${theme.highlightBackground};
-        outline-offset: 2px;
-    }
-
-    span {
-        font-size: 14px;
-        font-weight: 600;
-        letter-spacing: 1px;
-        line-height: 1;
+        background: ${theme.buttonBackgroundHover};
     }
 `;
 
-export const mobileMenuIcon = (theme: Theme): SerializedStyles => css`
+export const mobilePanelTitle = (theme: Theme): SerializedStyles => css`
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
     color: ${theme.headerTextColor};
 `;
 
-export const mobileDropdownList = (theme: Theme): SerializedStyles => css`
-    ${dropdownList(theme)}
-    position: fixed;
-    top: 56px;
-    left: 8px;
-    right: 8px;
-    width: auto;
-    max-height: calc(100vh - 72px);
+export const mobilePanelList = css`
+    list-style: none;
+    margin: 0;
+    padding: 6px;
     overflow-y: auto;
-    margin-top: 0;
+    min-height: 0;
 `;
 
 export const mobileBackItem = (theme: Theme): SerializedStyles => css`
@@ -76,7 +200,7 @@ export const mobileBackItem = (theme: Theme): SerializedStyles => css`
 
 export const mobileBackIcon = (theme: Theme): SerializedStyles => css`
     color: ${theme.headerTextColor};
-    margin-left: 6px;
+    margin-left: 0;
 `;
 
 export const selectedIcon = (theme: Theme): SerializedStyles => css`

--- a/src/components/menu-bar/types.ts
+++ b/src/components/menu-bar/types.ts
@@ -1,3 +1,5 @@
+import { IHotKeysCallbacks } from "@comp/hot-keys/types";
+
 // type MenuItemType = "normal" | "separator";
 
 export interface MenuItemDef {
@@ -5,7 +7,7 @@ export interface MenuItemDef {
     disabled?: boolean;
     doc?: string;
     checked?: boolean;
-    hotKey?: string;
+    hotKey?: keyof IHotKeysCallbacks;
     label?: string;
     seperator?: boolean;
     submenu?: MenuItemDef[];

--- a/src/components/menu-ui/actions.ts
+++ b/src/components/menu-ui/actions.ts
@@ -1,0 +1,47 @@
+import {
+    CLOSE_HEADER_DRAWER,
+    CLOSE_MOBILE_TOP_MENU,
+    OPEN_HEADER_DRAWER,
+    POP_MOBILE_TOP_MENU_PATH,
+    PUSH_MOBILE_TOP_MENU_PATH,
+    RESET_MOBILE_TOP_MENU_PATH,
+    TOGGLE_MOBILE_TOP_MENU,
+    CloseHeaderDrawerAction,
+    CloseMobileTopMenuAction,
+    OpenHeaderDrawerAction,
+    PopMobileTopMenuPathAction,
+    PushMobileTopMenuPathAction,
+    ResetMobileTopMenuPathAction,
+    ToggleMobileTopMenuAction
+} from "./types";
+
+export const openHeaderDrawer = (): OpenHeaderDrawerAction => ({
+    type: OPEN_HEADER_DRAWER
+});
+
+export const closeHeaderDrawer = (): CloseHeaderDrawerAction => ({
+    type: CLOSE_HEADER_DRAWER
+});
+
+export const toggleMobileTopMenu = (): ToggleMobileTopMenuAction => ({
+    type: TOGGLE_MOBILE_TOP_MENU
+});
+
+export const closeMobileTopMenu = (): CloseMobileTopMenuAction => ({
+    type: CLOSE_MOBILE_TOP_MENU
+});
+
+export const pushMobileTopMenuPath = (
+    index: number
+): PushMobileTopMenuPathAction => ({
+    type: PUSH_MOBILE_TOP_MENU_PATH,
+    index
+});
+
+export const popMobileTopMenuPath = (): PopMobileTopMenuPathAction => ({
+    type: POP_MOBILE_TOP_MENU_PATH
+});
+
+export const resetMobileTopMenuPath = (): ResetMobileTopMenuPathAction => ({
+    type: RESET_MOBILE_TOP_MENU_PATH
+});

--- a/src/components/menu-ui/actions.ts
+++ b/src/components/menu-ui/actions.ts
@@ -6,13 +6,17 @@ import {
     PUSH_MOBILE_TOP_MENU_PATH,
     RESET_MOBILE_TOP_MENU_PATH,
     TOGGLE_MOBILE_TOP_MENU,
+    TOGGLE_MOBILE_DOCK,
+    CLOSE_MOBILE_DOCK,
     CloseHeaderDrawerAction,
     CloseMobileTopMenuAction,
     OpenHeaderDrawerAction,
     PopMobileTopMenuPathAction,
     PushMobileTopMenuPathAction,
     ResetMobileTopMenuPathAction,
-    ToggleMobileTopMenuAction
+    ToggleMobileTopMenuAction,
+    ToggleMobileDockAction,
+    CloseMobileDockAction
 } from "./types";
 
 export const openHeaderDrawer = (): OpenHeaderDrawerAction => ({
@@ -44,4 +48,12 @@ export const popMobileTopMenuPath = (): PopMobileTopMenuPathAction => ({
 
 export const resetMobileTopMenuPath = (): ResetMobileTopMenuPathAction => ({
     type: RESET_MOBILE_TOP_MENU_PATH
+});
+
+export const toggleMobileDock = (): ToggleMobileDockAction => ({
+    type: TOGGLE_MOBILE_DOCK
+});
+
+export const closeMobileDock = (): CloseMobileDockAction => ({
+    type: CLOSE_MOBILE_DOCK
 });

--- a/src/components/menu-ui/reducer.ts
+++ b/src/components/menu-ui/reducer.ts
@@ -6,19 +6,23 @@ import {
     POP_MOBILE_TOP_MENU_PATH,
     PUSH_MOBILE_TOP_MENU_PATH,
     RESET_MOBILE_TOP_MENU_PATH,
-    TOGGLE_MOBILE_TOP_MENU
+    TOGGLE_MOBILE_TOP_MENU,
+    TOGGLE_MOBILE_DOCK,
+    CLOSE_MOBILE_DOCK
 } from "./types";
 
 export interface IMenuUiReducer {
     isHeaderDrawerOpen: boolean;
     isMobileTopMenuOpen: boolean;
     mobileTopMenuPath: number[];
+    isMobileDockOpen: boolean;
 }
 
 const INITIAL_STATE: IMenuUiReducer = {
     isHeaderDrawerOpen: false,
     isMobileTopMenuOpen: false,
-    mobileTopMenuPath: []
+    mobileTopMenuPath: [],
+    isMobileDockOpen: false
 };
 
 const MenuUiReducer = (
@@ -70,7 +74,14 @@ const MenuUiReducer = (
             };
         }
         case PUSH_MOBILE_TOP_MENU_PATH: {
-            const index = action.index as number;
+            const index = action.index;
+            if (
+                typeof index !== "number" ||
+                !Number.isInteger(index) ||
+                index < 0
+            ) {
+                return state;
+            }
             return {
                 ...state,
                 mobileTopMenuPath: [...state.mobileTopMenuPath, index]
@@ -91,6 +102,28 @@ const MenuUiReducer = (
             }
             return {
                 ...state,
+                mobileTopMenuPath: []
+            };
+        }
+        case TOGGLE_MOBILE_DOCK: {
+            const nextDockOpen = !state.isMobileDockOpen;
+            return {
+                ...state,
+                isMobileDockOpen: nextDockOpen,
+                isMobileTopMenuOpen: nextDockOpen
+                    ? state.isMobileTopMenuOpen
+                    : false,
+                mobileTopMenuPath: nextDockOpen ? state.mobileTopMenuPath : []
+            };
+        }
+        case CLOSE_MOBILE_DOCK: {
+            if (!state.isMobileDockOpen) {
+                return state;
+            }
+            return {
+                ...state,
+                isMobileDockOpen: false,
+                isMobileTopMenuOpen: false,
                 mobileTopMenuPath: []
             };
         }

--- a/src/components/menu-ui/reducer.ts
+++ b/src/components/menu-ui/reducer.ts
@@ -1,0 +1,103 @@
+import { UnknownAction } from "@reduxjs/toolkit";
+import {
+    CLOSE_HEADER_DRAWER,
+    CLOSE_MOBILE_TOP_MENU,
+    OPEN_HEADER_DRAWER,
+    POP_MOBILE_TOP_MENU_PATH,
+    PUSH_MOBILE_TOP_MENU_PATH,
+    RESET_MOBILE_TOP_MENU_PATH,
+    TOGGLE_MOBILE_TOP_MENU
+} from "./types";
+
+export interface IMenuUiReducer {
+    isHeaderDrawerOpen: boolean;
+    isMobileTopMenuOpen: boolean;
+    mobileTopMenuPath: number[];
+}
+
+const INITIAL_STATE: IMenuUiReducer = {
+    isHeaderDrawerOpen: false,
+    isMobileTopMenuOpen: false,
+    mobileTopMenuPath: []
+};
+
+const MenuUiReducer = (
+    state: IMenuUiReducer | undefined,
+    action: UnknownAction
+): IMenuUiReducer => {
+    if (!state) {
+        return INITIAL_STATE;
+    }
+
+    switch (action.type) {
+        case OPEN_HEADER_DRAWER: {
+            if (state.isHeaderDrawerOpen) {
+                return state;
+            }
+            return {
+                ...state,
+                isHeaderDrawerOpen: true
+            };
+        }
+        case CLOSE_HEADER_DRAWER: {
+            if (!state.isHeaderDrawerOpen) {
+                return state;
+            }
+            return {
+                ...state,
+                isHeaderDrawerOpen: false
+            };
+        }
+        case TOGGLE_MOBILE_TOP_MENU: {
+            const nextOpen = !state.isMobileTopMenuOpen;
+            return {
+                ...state,
+                isMobileTopMenuOpen: nextOpen,
+                mobileTopMenuPath: nextOpen ? state.mobileTopMenuPath : []
+            };
+        }
+        case CLOSE_MOBILE_TOP_MENU: {
+            if (
+                !state.isMobileTopMenuOpen &&
+                state.mobileTopMenuPath.length === 0
+            ) {
+                return state;
+            }
+            return {
+                ...state,
+                isMobileTopMenuOpen: false,
+                mobileTopMenuPath: []
+            };
+        }
+        case PUSH_MOBILE_TOP_MENU_PATH: {
+            const index = action.index as number;
+            return {
+                ...state,
+                mobileTopMenuPath: [...state.mobileTopMenuPath, index]
+            };
+        }
+        case POP_MOBILE_TOP_MENU_PATH: {
+            if (state.mobileTopMenuPath.length === 0) {
+                return state;
+            }
+            return {
+                ...state,
+                mobileTopMenuPath: state.mobileTopMenuPath.slice(0, -1)
+            };
+        }
+        case RESET_MOBILE_TOP_MENU_PATH: {
+            if (state.mobileTopMenuPath.length === 0) {
+                return state;
+            }
+            return {
+                ...state,
+                mobileTopMenuPath: []
+            };
+        }
+        default: {
+            return state;
+        }
+    }
+};
+
+export default MenuUiReducer;

--- a/src/components/menu-ui/selectors.ts
+++ b/src/components/menu-ui/selectors.ts
@@ -8,3 +8,6 @@ export const selectIsMobileTopMenuOpen = (state: RootState): boolean =>
 
 export const selectMobileTopMenuPath = (state: RootState): number[] =>
     state.MenuUiReducer.mobileTopMenuPath;
+
+export const selectIsMobileDockOpen = (state: RootState): boolean =>
+    state.MenuUiReducer.isMobileDockOpen;

--- a/src/components/menu-ui/selectors.ts
+++ b/src/components/menu-ui/selectors.ts
@@ -1,0 +1,10 @@
+import { RootState } from "@root/store";
+
+export const selectIsHeaderDrawerOpen = (state: RootState): boolean =>
+    state.MenuUiReducer.isHeaderDrawerOpen;
+
+export const selectIsMobileTopMenuOpen = (state: RootState): boolean =>
+    state.MenuUiReducer.isMobileTopMenuOpen;
+
+export const selectMobileTopMenuPath = (state: RootState): number[] =>
+    state.MenuUiReducer.mobileTopMenuPath;

--- a/src/components/menu-ui/types.ts
+++ b/src/components/menu-ui/types.ts
@@ -5,6 +5,8 @@ export const CLOSE_MOBILE_TOP_MENU = "CLOSE_MOBILE_TOP_MENU";
 export const PUSH_MOBILE_TOP_MENU_PATH = "PUSH_MOBILE_TOP_MENU_PATH";
 export const POP_MOBILE_TOP_MENU_PATH = "POP_MOBILE_TOP_MENU_PATH";
 export const RESET_MOBILE_TOP_MENU_PATH = "RESET_MOBILE_TOP_MENU_PATH";
+export const TOGGLE_MOBILE_DOCK = "TOGGLE_MOBILE_DOCK";
+export const CLOSE_MOBILE_DOCK = "CLOSE_MOBILE_DOCK";
 
 interface MenuUiBaseAction {
     type: string;
@@ -40,6 +42,14 @@ export interface ResetMobileTopMenuPathAction extends MenuUiBaseAction {
     type: typeof RESET_MOBILE_TOP_MENU_PATH;
 }
 
+export interface ToggleMobileDockAction extends MenuUiBaseAction {
+    type: typeof TOGGLE_MOBILE_DOCK;
+}
+
+export interface CloseMobileDockAction extends MenuUiBaseAction {
+    type: typeof CLOSE_MOBILE_DOCK;
+}
+
 export type MenuUiActionTypes =
     | OpenHeaderDrawerAction
     | CloseHeaderDrawerAction
@@ -47,4 +57,6 @@ export type MenuUiActionTypes =
     | CloseMobileTopMenuAction
     | PushMobileTopMenuPathAction
     | PopMobileTopMenuPathAction
-    | ResetMobileTopMenuPathAction;
+    | ResetMobileTopMenuPathAction
+    | ToggleMobileDockAction
+    | CloseMobileDockAction;

--- a/src/components/menu-ui/types.ts
+++ b/src/components/menu-ui/types.ts
@@ -1,0 +1,50 @@
+export const OPEN_HEADER_DRAWER = "OPEN_HEADER_DRAWER";
+export const CLOSE_HEADER_DRAWER = "CLOSE_HEADER_DRAWER";
+export const TOGGLE_MOBILE_TOP_MENU = "TOGGLE_MOBILE_TOP_MENU";
+export const CLOSE_MOBILE_TOP_MENU = "CLOSE_MOBILE_TOP_MENU";
+export const PUSH_MOBILE_TOP_MENU_PATH = "PUSH_MOBILE_TOP_MENU_PATH";
+export const POP_MOBILE_TOP_MENU_PATH = "POP_MOBILE_TOP_MENU_PATH";
+export const RESET_MOBILE_TOP_MENU_PATH = "RESET_MOBILE_TOP_MENU_PATH";
+
+interface MenuUiBaseAction {
+    type: string;
+    [key: string]: unknown;
+}
+
+export interface OpenHeaderDrawerAction extends MenuUiBaseAction {
+    type: typeof OPEN_HEADER_DRAWER;
+}
+
+export interface CloseHeaderDrawerAction extends MenuUiBaseAction {
+    type: typeof CLOSE_HEADER_DRAWER;
+}
+
+export interface ToggleMobileTopMenuAction extends MenuUiBaseAction {
+    type: typeof TOGGLE_MOBILE_TOP_MENU;
+}
+
+export interface CloseMobileTopMenuAction extends MenuUiBaseAction {
+    type: typeof CLOSE_MOBILE_TOP_MENU;
+}
+
+export interface PushMobileTopMenuPathAction extends MenuUiBaseAction {
+    type: typeof PUSH_MOBILE_TOP_MENU_PATH;
+    index: number;
+}
+
+export interface PopMobileTopMenuPathAction extends MenuUiBaseAction {
+    type: typeof POP_MOBILE_TOP_MENU_PATH;
+}
+
+export interface ResetMobileTopMenuPathAction extends MenuUiBaseAction {
+    type: typeof RESET_MOBILE_TOP_MENU_PATH;
+}
+
+export type MenuUiActionTypes =
+    | OpenHeaderDrawerAction
+    | CloseHeaderDrawerAction
+    | ToggleMobileTopMenuAction
+    | CloseMobileTopMenuAction
+    | PushMobileTopMenuPathAction
+    | PopMobileTopMenuPathAction
+    | ResetMobileTopMenuPathAction;

--- a/src/components/project-editor/mobile-navigation.tsx
+++ b/src/components/project-editor/mobile-navigation.tsx
@@ -3,9 +3,14 @@ import AutoStoriesRoundedIcon from "@mui/icons-material/AutoStoriesRounded";
 import ListAltRoundedIcon from "@mui/icons-material/ListAltRounded";
 import AccountTree from "@mui/icons-material/AccountTree";
 import FormatTextdirectionLToR from "@mui/icons-material/FormatTextdirectionLToR";
-import BottomNavigation from "@mui/material/BottomNavigation";
-import BottomNavigationAction from "@mui/material/BottomNavigationAction";
 import * as SS from "./styles";
+
+const tabs = [
+    { label: "Edit", Icon: FormatTextdirectionLToR, index: 0 },
+    { label: "Files", Icon: AccountTree, index: 1 },
+    { label: "Console", Icon: ListAltRoundedIcon, index: 2 },
+    { label: "Manual", Icon: AutoStoriesRoundedIcon, index: 3 }
+] as const;
 
 const MobileNavigation = ({
     mobileTabIndex,
@@ -15,40 +20,23 @@ const MobileNavigation = ({
     setMobileTabIndex: (index: number) => void;
 }): React.ReactElement => {
     return (
-        <BottomNavigation
-            value={mobileTabIndex}
-            css={SS.mobileNavigationContainer}
-            showLabels
-        >
-            <BottomNavigationAction
-                value={0}
-                onClick={() => setMobileTabIndex(0)}
-                css={SS.mobileNavigationButton}
-                label="Edit"
-                icon={<FormatTextdirectionLToR fontSize="large" />}
-            ></BottomNavigationAction>
-            <BottomNavigationAction
-                value={1}
-                onClick={() => setMobileTabIndex(1)}
-                css={SS.mobileNavigationButton}
-                label="File Tree"
-                icon={<AccountTree fontSize="large" />}
-            ></BottomNavigationAction>
-            <BottomNavigationAction
-                value={2}
-                onClick={() => setMobileTabIndex(2)}
-                css={SS.mobileNavigationButton}
-                label="Console"
-                icon={<ListAltRoundedIcon fontSize="large" />}
-            ></BottomNavigationAction>
-            <BottomNavigationAction
-                value={3}
-                onClick={() => setMobileTabIndex(3)}
-                css={SS.mobileNavigationButton}
-                label="Manual"
-                icon={<AutoStoriesRoundedIcon fontSize="large" />}
-            ></BottomNavigationAction>
-        </BottomNavigation>
+        <div css={SS.mobileNavContainer}>
+            <div css={SS.mobileNavTabGroup}>
+                {tabs.map(({ label, Icon, index }) => (
+                    <button
+                        key={index}
+                        type="button"
+                        css={SS.mobileNavTabButton(mobileTabIndex === index)}
+                        onClick={() => setMobileTabIndex(index)}
+                        aria-label={label}
+                        aria-selected={mobileTabIndex === index}
+                    >
+                        <Icon />
+                        <span>{label}</span>
+                    </button>
+                ))}
+            </div>
+        </div>
     );
 };
 

--- a/src/components/project-editor/styles.ts
+++ b/src/components/project-editor/styles.ts
@@ -101,3 +101,55 @@ export const mobileFileTree = css`
         padding: 0 !important;
     }
 `;
+
+// ── New custom mobile bottom navigation ──────────────────────────────────────
+
+export const mobileNavContainer = (theme: Theme): SerializedStyles => css`
+    background-color: ${theme.headerBackground};
+    position: fixed;
+    width: 100%;
+    bottom: 0;
+    z-index: 10;
+    height: 56px;
+    display: flex;
+    align-items: stretch;
+    ${shadow};
+    border-top: 1px solid ${theme.line};
+`;
+
+export const mobileNavTabGroup = css`
+    display: flex;
+    align-items: stretch;
+    flex: 1;
+`;
+
+export const mobileNavTabButton =
+    (isActive: boolean) =>
+    (theme: Theme): SerializedStyles => css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 2px;
+        flex: 1;
+        border: 0;
+        border-left: 1px solid ${theme.line};
+        border-top: 2px solid
+            ${isActive ? theme.headerTextColor : "transparent"};
+        background: transparent;
+        color: ${theme.headerTextColor};
+        opacity: ${isActive ? 1 : 0.6};
+        cursor: pointer;
+        font-size: 10px;
+        padding: 4px 2px;
+        transition: opacity 0.15s;
+
+        &:hover {
+            opacity: 1;
+            background: ${theme.buttonBackgroundHover};
+        }
+
+        svg {
+            font-size: 20px;
+        }
+    `;

--- a/src/components/target-controls/index.tsx
+++ b/src/components/target-controls/index.tsx
@@ -9,6 +9,8 @@ import { setSelectedTarget } from "./actions";
 import { values } from "ramda";
 import StopButton from "./stop-button";
 import { findFallbackTargetName } from "./utils";
+import { isMobile } from "@root/utils";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 export const TargetControls = ({
     activeProjectUid
@@ -21,6 +23,8 @@ export const TargetControls = ({
         useSelector(selectSelectedTarget);
 
     const isOwner = useSelector(selectIsOwner);
+    const isCompactViewport = useMediaQuery("(max-width:900px)");
+    const mobileView = isMobile() || isCompactViewport;
 
     const targets: ITargetMap | undefined = useSelector(
         selectProjectTargets(activeProjectUid)
@@ -69,7 +73,9 @@ export const TargetControls = ({
         <>
             <PlayButton activeProjectUid={activeProjectUid} isOwner={isOwner} />
             <StopButton />
-            {isOwner && <TargetDropdown activeProjectUid={activeProjectUid} />}
+            {isOwner && !mobileView && (
+                <TargetDropdown activeProjectUid={activeProjectUid} />
+            )}
         </>
     ) : (
         <></>

--- a/src/store/root-reducer.tsx
+++ b/src/store/root-reducer.tsx
@@ -8,6 +8,7 @@ import HotKeysReducer from "@comp/hot-keys/reducer";
 import IDReducer from "../db/id-reducer";
 import LoginReducer from "@comp/login/reducer";
 import ModalReducer from "@comp/modal/reducer";
+import MenuUiReducer from "@comp/menu-ui/reducer";
 import ProfileReducer from "@comp/profile/reducer";
 import ProjectEditorReducer from "@comp/project-editor/reducer";
 import ProjectLastModifiedReducer from "@comp/project-last-modified/reducer";
@@ -24,6 +25,7 @@ export const reducer = {
     csound: CsoundReducer,
     FileTreeReducer,
     ThemeReducer,
+    MenuUiReducer,
     ModalReducer,
     ConsoleReducer,
     ProfileReducer,

--- a/src/styles/web-ide-css-baseline.tsx
+++ b/src/styles/web-ide-css-baseline.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Theme } from "@emotion/react";
-import { headerHeight } from "@styles/constants";
 
 const WebIdeCssBaseline = ({ theme }: { theme: Theme }): React.ReactElement => (
     <style>{`
@@ -31,6 +30,13 @@ body {
     padding: 0!important;
     overflow: auto!important;
     min-height: 100vh;
+}
+
+@media (max-width: 900px) {
+  body.mobile-left-menu-docked main {
+    box-sizing: border-box;
+    padding-left: 104px;
+  }
 }
 
 #root {


### PR DESCRIPTION
Enhance the mobile view by implementing a top menu that can be toggled open and closed. 

This includes state management for the menu's visibility and path handling for navigation. 

Related issue https://github.com/csound/web-ide/issues/431