### PR TITLE
feature: modal view for available opcodes

### DIFF
--- a/src/components/csound/actions.ts
+++ b/src/components/csound/actions.ts
@@ -1,12 +1,13 @@
 import { AppThunkDispatch, RootState, store } from "@root/store";
 import { IDocument, IProject } from "../projects/types";
-import { Csound } from "@csound/browser";
+import { Csound, libcsound } from "@csound/browser";
 import {
     cleanupNonCloudFiles,
     nonCloudFiles,
     addNonCloudFile
 } from "@comp/file-tree/actions";
 import { openSnackbar } from "@comp/snackbar/actions";
+import { openSimpleModal } from "@comp/modal/actions";
 import { SnackbarType } from "@comp/snackbar/types";
 import {
     CsoundObj,
@@ -572,4 +573,34 @@ export const renderToDisk = (
             );
         }
     };
+};
+
+export const listAvailableOpcodes = async (): Promise<void> => {
+    let lib: Awaited<ReturnType<typeof libcsound>> | undefined;
+    try {
+        lib = await libcsound();
+    } catch {
+        store.dispatch(
+            openSnackbar("Failed to load Csound library", SnackbarType.Error)
+        );
+        return;
+    }
+
+    const csound = lib.csoundCreate();
+    const factory = lib.csoundUgenFactoryNew(csound);
+    const rawOpcodes = lib.csoundUgenListOpcodes(factory);
+    lib.csoundUgenFactoryDelete(factory);
+    lib.csoundDestroy(csound);
+
+    if (!rawOpcodes || rawOpcodes.length === 0) {
+        store.dispatch(
+            openSnackbar(
+                "No opcodes returned from Csound library",
+                SnackbarType.Warning
+            )
+        );
+        return;
+    }
+
+    store.dispatch(openSimpleModal("opcode-list", { opcodes: rawOpcodes }));
 };

--- a/src/components/menu-bar/menu-bar.tsx
+++ b/src/components/menu-bar/menu-bar.tsx
@@ -30,7 +30,7 @@ import {
     toggleManualPanel,
     setFileTreePanelOpen
 } from "@comp/project-editor/actions";
-import { renderToDisk } from "@comp/csound/actions";
+import { renderToDisk, listAvailableOpcodes } from "@comp/csound/actions";
 import { selectCsoundStatus } from "@comp/csound/selectors";
 import { selectIsOwner } from "@comp/project-editor/selectors";
 import { changeTheme } from "@comp/themes/action";
@@ -306,6 +306,13 @@ export function MenuBar() {
                     {
                         label: "Show Keyboard Shortcuts",
                         callback: () => dispatch(showKeyboardShortcuts())
+                    },
+                    {
+                        seperator: true
+                    },
+                    {
+                        label: "List Available Opcodes",
+                        callback: listAvailableOpcodes
                     }
                 ]
             }
@@ -422,6 +429,7 @@ export function MenuBar() {
 
             if (mobileView) {
                 dispatch(closeMobileTopMenu());
+                dispatch(closeMobileDock());
             }
         },
         [dispatch, mobileView]

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -3,6 +3,7 @@ import { RootState, useDispatch, useSelector } from "@root/store";
 import { TargetControlsConfigDialog } from "@comp/target-controls/config-dialog";
 import ShareDialog from "@comp/share-dialog";
 import { KeyboardShortcuts } from "@comp/site-documents/keyboard-shortcuts";
+import { OpcodeList, OpcodeListProps } from "@comp/site-documents/opcode-list";
 import {
     AddDocumentPrompt,
     DeleteDocumentPrompt,
@@ -126,6 +127,9 @@ export default function GlobalModal() {
                     )}
                     {modalComponentName === "keyboard-shortcuts" && (
                         <KeyboardShortcuts {...modalProperties} />
+                    )}
+                    {modalComponentName === "opcode-list" && (
+                        <OpcodeList {...(modalProperties as OpcodeListProps)} />
                     )}
                     {modalComponentName === "new-document-prompt" && (
                         <NewDocumentPrompt {...(modalProperties as any)} />

--- a/src/components/site-documents/opcode-list.tsx
+++ b/src/components/site-documents/opcode-list.tsx
@@ -1,0 +1,122 @@
+import React, { useMemo, useState } from "react";
+import { css, Theme } from "@emotion/react";
+
+export interface OpcodeInfo {
+    opname: string;
+    outypes: string;
+    intypes: string;
+}
+
+export interface OpcodeListProps {
+    opcodes: OpcodeInfo[];
+}
+
+const containerCss = css`
+    width: 640px;
+    max-width: calc(100vw - 60px);
+`;
+
+const titleCss = css`
+    margin: 0 0 12px;
+`;
+
+const searchCss = (theme: Theme) => css`
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 10px;
+    margin-bottom: 14px;
+    border-radius: 4px;
+    border: 1px solid ${theme.line};
+    background: transparent;
+    color: inherit;
+    font-size: 14px;
+    &:focus {
+        outline: none;
+        border-color: ${theme.lineHover};
+    }
+`;
+
+const listCss = css`
+    max-height: 55vh;
+    overflow-y: auto;
+    font-family: monospace;
+    font-size: 13px;
+`;
+
+const groupCss = css`
+    margin-bottom: 10px;
+`;
+
+const opnameCss = css`
+    font-weight: bold;
+    margin-bottom: 2px;
+`;
+
+const signatureCss = css`
+    padding-left: 16px;
+    opacity: 0.8;
+    white-space: nowrap;
+`;
+
+const countCss = css`
+    font-size: 12px;
+    opacity: 0.6;
+    margin-bottom: 10px;
+`;
+
+export const OpcodeList = ({ opcodes }: OpcodeListProps) => {
+    const [filter, setFilter] = useState("");
+
+    // Group signatures by opcode name
+    const grouped = useMemo(() => {
+        const map = new Map<string, OpcodeInfo[]>();
+        for (const entry of opcodes) {
+            const existing = map.get(entry.opname);
+            if (existing) {
+                existing.push(entry);
+            } else {
+                map.set(entry.opname, [entry]);
+            }
+        }
+        return map;
+    }, [opcodes]);
+
+    const filteredEntries = useMemo(() => {
+        const q = filter.trim().toLowerCase();
+        const entries = [...grouped.entries()].sort(([a], [b]) =>
+            a.localeCompare(b)
+        );
+        return q
+            ? entries.filter(([name]) => name.toLowerCase().includes(q))
+            : entries;
+    }, [filter, grouped]);
+
+    return (
+        <div css={containerCss}>
+            <h3 css={titleCss}>Available Opcodes</h3>
+            <input
+                css={searchCss}
+                type="text"
+                placeholder="Filter opcodes…"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                autoFocus
+            />
+            <p css={countCss}>
+                {filteredEntries.length} / {grouped.size} opcodes
+            </p>
+            <div css={listCss}>
+                {filteredEntries.map(([name, variants]) => (
+                    <div key={name} css={groupCss}>
+                        <div css={opnameCss}>{name}</div>
+                        {variants.map((v, i) => (
+                            <div key={i} css={signatureCss}>
+                                {v.outypes || "_"} {name} {v.intypes || "_"}
+                            </div>
+                        ))}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows users to view a searchable, grouped list of all available Csound opcodes via the menu bar. It fetches opcode information from the Csound library, displays the results in a new modal dialog.

Related Issue https://github.com/csound/web-ide/issues/461