### PR TITLE
fix: correct inverted editor resize handle behavior

### DIFF
--- a/src/components/project-editor/project-editor.tsx
+++ b/src/components/project-editor/project-editor.tsx
@@ -556,7 +556,9 @@ const WorkspaceNodeView = ({
                         panelCount={panelCount}
                     />
                 </ResizablePanel>
-                <PanelResizeHandle className={`Resizer ${node.direction}`} />
+                <PanelResizeHandle
+                    className={`ProjectEditorResizer ${node.direction}`}
+                />
                 <ResizablePanel defaultSize={50}>
                     <WorkspaceNodeView
                         node={node.second}
@@ -1038,7 +1040,7 @@ const ProjectEditor = ({
                 />
             </ResizablePanel>
             <PanelResizeHandle
-                className="Resizer horizontal"
+                className="ProjectEditorResizer horizontal"
                 onDragging={(dragging) => setIsDragging(dragging)}
             />
             <ResizablePanel defaultSize={24}>
@@ -1127,7 +1129,7 @@ const ProjectEditor = ({
                                                 />
                                             </ResizablePanel>
                                             <PanelResizeHandle
-                                                className="Resizer vertical"
+                                                className="ProjectEditorResizer vertical"
                                                 onDragging={(dragging) =>
                                                     setIsDragging(dragging)
                                                 }
@@ -1143,7 +1145,7 @@ const ProjectEditor = ({
                                     {rightSidebar && (
                                         <>
                                             <PanelResizeHandle
-                                                className="Resizer vertical"
+                                                className="ProjectEditorResizer vertical"
                                                 onDragging={(dragging) =>
                                                     setIsDragging(dragging)
                                                 }

--- a/src/components/project-editor/styles.ts
+++ b/src/components/project-editor/styles.ts
@@ -27,7 +27,7 @@ export const splitterRoot = (theme: Theme): SerializedStyles => css`
         width: 100%;
     }
 
-    .Resizer {
+    .ProjectEditorResizer {
         flex: 0 0 auto;
         position: relative;
         z-index: 5;
@@ -35,19 +35,19 @@ export const splitterRoot = (theme: Theme): SerializedStyles => css`
         transition: background-color 0.15s ease;
     }
 
-    .Resizer.vertical {
+    .ProjectEditorResizer.vertical {
         width: 6px;
         cursor: col-resize;
     }
 
-    .Resizer.horizontal {
+    .ProjectEditorResizer.horizontal {
         height: 6px;
         cursor: row-resize;
     }
 
-    .Resizer:hover,
-    .Resizer[data-resize-handle-active="pointer"],
-    .Resizer[data-resize-handle-state="drag"] {
+    .ProjectEditorResizer:hover,
+    .ProjectEditorResizer[data-resize-handle-active="pointer"],
+    .ProjectEditorResizer[data-resize-handle-state="drag"] {
         background-color: rgba(255, 255, 255, 0.14);
     }
 `;


### PR DESCRIPTION
currently you resize and it's inverted