### PR TITLE
fix: initial open file regression

### DIFF
--- a/src/components/project-editor/actions.tsx
+++ b/src/components/project-editor/actions.tsx
@@ -34,6 +34,29 @@ import {
 const WORKSPACE_LAYOUT_STORAGE_KEY = (projectUid: string) =>
     `${projectUid}:workspaceLayout`;
 
+const findDocumentByFilename = (
+    documents: IDocument[],
+    filename: string
+): IDocument | undefined =>
+    documents.find((document) => document.filename === filename);
+
+const findFirstDocumentByExtensions = (
+    documents: IDocument[],
+    extensions: string[]
+): IDocument | undefined =>
+    documents.find((document) =>
+        extensions.some((extension) => document.filename.endsWith(extension))
+    );
+
+const findInitialFallbackDocument = (
+    documents: IDocument[]
+): IDocument | undefined =>
+    findDocumentByFilename(documents, "README.md") ||
+    findDocumentByFilename(documents, "project.csd") ||
+    findFirstDocumentByExtensions(documents, [".csd"]) ||
+    findFirstDocumentByExtensions(documents, [".sco", ".orc"]) ||
+    (documents.length === 1 ? documents[0] : undefined);
+
 export const tabDockInit = (
     projectUid: string,
     allDocuments: IDocument[],
@@ -75,68 +98,22 @@ export const tabDockInit = (
         }
     }
 
-    if (
-        defaultTarget &&
-        defaultTarget.targetDocumentUid &&
-        initialOpenDocuments.length === 0 &&
-        allDocuments.length > 0
-    ) {
-        initialOpenDocuments.push({
-            uid: defaultTarget.targetDocumentUid
-        });
-    } else if (
-        defaultTarget &&
-        defaultTarget.playlistDocumentsUid &&
-        initialOpenDocuments.length === 0 &&
-        allDocuments.length > 0
-    ) {
-        defaultTarget.playlistDocumentsUid.forEach((documentUid) => {
-            initialOpenDocuments.push({
-                uid: documentUid
-            });
-        });
-    } else if (
-        allDocuments.length > 0 &&
-        allDocuments.some((d) => d.filename === "project.csd")
-    ) {
-        const projectCsd = allDocuments.find(
-            (d) => d.filename === "project.csd"
-        );
-
-        projectCsd &&
-            !initialOpenDocuments.find(
-                (d) => d.uid === projectCsd.documentUid
-            ) &&
-            initialOpenDocuments.push({
-                uid: projectCsd.documentUid
-            });
-    }
-
-    // Additional fallback logic for when no tabs are open yet
     if (initialOpenDocuments.length === 0 && allDocuments.length > 0) {
-        // First, try to find any .csd file
-        const csdFiles = allDocuments.filter((d) =>
-            d.filename.endsWith(".csd")
-        );
-        if (csdFiles.length > 0) {
+        const fallbackDocument = findInitialFallbackDocument(allDocuments);
+        if (fallbackDocument) {
             initialOpenDocuments.push({
-                uid: csdFiles[0].documentUid
+                uid: fallbackDocument.documentUid
             });
-        } else {
-            // If no .csd files, try to find any .orc file
-            const orcFiles = allDocuments.filter((d) =>
-                d.filename.endsWith(".orc")
-            );
-            if (orcFiles.length > 0) {
+        } else if (defaultTarget?.targetDocumentUid) {
+            initialOpenDocuments.push({
+                uid: defaultTarget.targetDocumentUid
+            });
+        } else if (defaultTarget?.playlistDocumentsUid) {
+            defaultTarget.playlistDocumentsUid.forEach((documentUid) => {
                 initialOpenDocuments.push({
-                    uid: orcFiles[0].documentUid
+                    uid: documentUid
                 });
-            } else if (allDocuments.length === 1) {
-                // If there's only 1 file/document, open it
-                initialOpenDocuments.push({
-                    uid: allDocuments[0].documentUid
-                });
-            }
+            });
         }
     }
 

--- a/src/components/project-editor/reducer.ts
+++ b/src/components/project-editor/reducer.ts
@@ -394,6 +394,42 @@ const syncLegacyState = (
     };
 };
 
+const openInitialDocumentsInWorkspaceState = (
+    state: IProjectEditorReducer,
+    initialOpenDocuments: IOpenDocument[],
+    initialIndex: number
+): IProjectEditorReducer => {
+    if (initialOpenDocuments.length === 0) {
+        return state;
+    }
+
+    const panelId = containsPanel(state.root, state.activePanelId)
+        ? state.activePanelId
+        : findFirstPanelId(state.root);
+    const startTabNumber = state.nextTabNumber;
+    const tabs = initialOpenDocuments.map(
+        (openDocument: IOpenDocument, index: number) =>
+            createEditorTab(`tab-${startTabNumber + index}`, openDocument)
+    );
+    const safeInitialIndex = Math.max(
+        0,
+        Math.min(initialIndex, tabs.length - 1)
+    );
+
+    const [root] = mapPanel(state.root, panelId, (panel) => ({
+        ...panel,
+        tabs: [...panel.tabs, ...tabs],
+        tabIndex: panel.tabs.length + safeInitialIndex
+    }));
+
+    return syncLegacyState({
+        ...state,
+        root,
+        activePanelId: panelId,
+        nextTabNumber: startTabNumber + tabs.length
+    });
+};
+
 const getSidebarKey = (sidebar: SidebarPosition) => {
     if (sidebar === "left") return "leftSidebar" as const;
     if (sidebar === "right") return "rightSidebar" as const;
@@ -504,13 +540,23 @@ const ProjectEditorReducer = (
                 const savedWorkspaceState =
                     action.savedWorkspaceState as IPersistedWorkspaceLayout;
 
-                return syncLegacyState({
+                const restoredState = syncLegacyState({
                     ...initialLayoutState(),
                     ...savedWorkspaceState,
                     manualLookupString: "",
                     maximizedPanelId:
                         savedWorkspaceState.maximizedPanelId || null
                 });
+
+                if (restoredState.tabDock.openDocuments.length > 0) {
+                    return restoredState;
+                }
+
+                return openInitialDocumentsInWorkspaceState(
+                    restoredState,
+                    action.initialOpenDocuments as IOpenDocument[],
+                    action.initialIndex
+                );
             }
 
             const tabs = (action.initialOpenDocuments as IOpenDocument[]).map(


### PR DESCRIPTION
a behaviour where at least 1 file is open when visitors look at project. This seems to be gone. I fixed it but with a twist, README.md is now the nr 1 priority file to open on init, giving composers the possibility to describe their piece if they wish to use markdown for that purpose.