### PR TITLE
ci: make puppeteer tests timeouts less brittle

### DIFF
--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -1,20 +1,26 @@
 name: E2E — Dev
 
 on:
-    push:
+    workflow_run:
+        workflows: ["Deploy Develop"]
         branches: [develop]
+        types: [completed]
+    workflow_dispatch:
 
 concurrency:
-    group: e2e-dev-${{ github.sha }}
+    group: e2e-dev-${{ github.event.workflow_run.head_sha || github.sha }}
     cancel-in-progress: true
 
 jobs:
     install:
         name: Install dependencies
+        if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
             - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -50,6 +56,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Set up Node.js
               uses: actions/setup-node@v4

--- a/puppeteer-tests/tests/editor.js
+++ b/puppeteer-tests/tests/editor.js
@@ -5,6 +5,7 @@ import {
     waitForProject,
     openFileFromTree,
     findRunButton,
+    openConsolePanel,
     waitForConsoleOutput,
     getConsoleOutputLength,
     waitForConsoleOutputGrowth,
@@ -69,6 +70,9 @@ describe(`Editor [${targetName}]`, () => {
     it("runs and produces console output", async () => {
         const btn = await findRunButton(page);
         assert.ok(btn, "Run button not found");
+        await openConsolePanel(page);
+        const consoleOutput = await page.$('[data-testid="console-output"]');
+        assert.ok(consoleOutput, "Console panel not mounted before run");
         const beforeLength = await getConsoleOutputLength(page);
         await btn.click();
         await waitForConsoleOutputGrowth(page, beforeLength);


### PR DESCRIPTION
there's lite vs full puppeteer runs, it's the latter one that times out, could be just concurrency / timing problem