### PR TITLE
Load project WebAssembly plugins in Csound

### DIFF
--- a/src/components/csound/actions.ts
+++ b/src/components/csound/actions.ts
@@ -16,9 +16,14 @@ import {
     compileCSD
 } from "./types";
 import { selectActiveProject } from "@comp/projects/selectors";
-import { addDocumentToCsoundFS, getUniqueFilename } from "@comp/projects/utils";
+import {
+    addDocumentToCsoundFS,
+    getUniqueFilename,
+    loadBinaryDocument
+} from "@comp/projects/utils";
 import { getSelectedTargetDocumentUid } from "@comp/target-controls/selectors";
 import { append, isEmpty, difference } from "ramda";
+import { createCsoundForProject } from "./plugins";
 
 export let csoundInstance: CsoundObj;
 
@@ -142,8 +147,17 @@ export const playCsdFromFs = ({
     csdPath: string;
 }) => {
     return async (dispatch: AppThunkDispatch, setConsole: any) => {
-        const csoundObj = await Csound({
-            useWorker: localStorage.getItem("sab") === "true"
+        const pluginDocuments =
+            store.getState().ProjectsReducer.projects?.[projectUid]
+                ?.documents ?? {};
+        const csoundObj = await createCsoundForProject({
+            csoundFactory: Csound,
+            loadBinaryDocument,
+            projectUid,
+            documents: pluginDocuments,
+            options: {
+                useWorker: localStorage.getItem("sab") === "true"
+            }
         });
 
         if (!csoundObj) {
@@ -309,8 +323,17 @@ export const playORCFromString = ({
     orc: string;
 }): ((dispatch: any, setConsole: any) => Promise<void>) => {
     return async (dispatch, setConsole: any) => {
-        const csoundObj = await Csound({
-            useWorker: localStorage.getItem("sab") === "true"
+        const projectDocuments =
+            store.getState().ProjectsReducer.projects?.[projectUid]
+                ?.documents ?? {};
+        const csoundObj = await createCsoundForProject({
+            csoundFactory: Csound,
+            loadBinaryDocument,
+            projectUid,
+            documents: projectDocuments,
+            options: {
+                useWorker: localStorage.getItem("sab") === "true"
+            }
         });
 
         if (!csoundObj) {
@@ -399,8 +422,14 @@ export const renderToDisk = (
         }
 
         // Non-worker mode has more reliable render lifecycle events for offline -o rendering.
-        const csound = await Csound({
-            useWorker: false
+        const csound = await createCsoundForProject({
+            csoundFactory: Csound,
+            loadBinaryDocument,
+            projectUid: project.projectUid,
+            documents: project.documents,
+            options: {
+                useWorker: false
+            }
         });
 
         csoundInstance = csound as CsoundObj;

--- a/src/components/csound/plugins.test.ts
+++ b/src/components/csound/plugins.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Csound as BrowserCsoundFactory } from "@csound/browser";
+import type { IDocument } from "@comp/projects/types";
+import { createCsoundForProject } from "./plugins";
+
+const makeDocument = (overrides: Partial<IDocument>): IDocument => ({
+    currentValue: "",
+    created: 1,
+    documentUid: "document",
+    filename: "file.bin",
+    lastModified: 1,
+    savedValue: "",
+    type: "bin",
+    userUid: "user",
+    isModifiedLocally: false,
+    path: [],
+    ...overrides
+});
+
+const readBlobBytes = (blob: Blob): Promise<number[]> =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.addEventListener("load", () => {
+            resolve(Array.from(new Uint8Array(reader.result as ArrayBuffer)));
+        });
+        reader.addEventListener("error", () => reject(reader.error));
+        reader.readAsArrayBuffer(blob);
+    });
+
+describe("createCsoundForProject", () => {
+    it("loads every binary .wasm file before initializing Csound", async () => {
+        const documents = {
+            folder: makeDocument({
+                documentUid: "folder",
+                filename: "plugins.wasm",
+                type: "folder"
+            }),
+            rootPlugin: makeDocument({
+                documentUid: "root-plugin",
+                filename: "root.wasm"
+            }),
+            nestedPlugin: makeDocument({
+                documentUid: "nested-plugin",
+                filename: "effect.WASM",
+                path: ["folder"]
+            }),
+            audio: makeDocument({
+                documentUid: "audio",
+                filename: "sample.wav"
+            }),
+            textWasm: makeDocument({
+                documentUid: "text-wasm",
+                filename: "notes.wasm",
+                type: "txt"
+            })
+        };
+        const rootBytes = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+        const paddedNestedBytes = new Uint8Array([
+            255, 0, 97, 115, 109, 1, 0, 0, 0, 255
+        ]);
+        const nestedBytes = paddedNestedBytes.subarray(1, 9);
+        const loadBinaryDocument = vi.fn(
+            async (_projectUid: string, document: IDocument) =>
+                document.documentUid === "root-plugin" ? rootBytes : nestedBytes
+        );
+        const blobs: Blob[] = [];
+        const createObjectURL = vi.fn((blob: Blob) => {
+            blobs.push(blob);
+            return `blob:plugin-${blobs.length}`;
+        });
+        const revokeObjectURL = vi.fn();
+        const csoundFactory = vi.fn(async () => {
+            expect(revokeObjectURL).not.toHaveBeenCalled();
+            return undefined;
+        });
+
+        await createCsoundForProject({
+            csoundFactory: csoundFactory as unknown as BrowserCsoundFactory,
+            loadBinaryDocument,
+            projectUid: "project",
+            documents,
+            options: { useWorker: true },
+            createObjectURL,
+            revokeObjectURL
+        });
+
+        expect(
+            loadBinaryDocument.mock.calls.map(([projectUid, document]) => [
+                projectUid,
+                document.documentUid
+            ])
+        ).toEqual([
+            ["project", "root-plugin"],
+            ["project", "nested-plugin"]
+        ]);
+        expect(csoundFactory).toHaveBeenCalledWith({
+            useWorker: true,
+            withPlugins: ["blob:plugin-1", "blob:plugin-2"]
+        });
+        expect(blobs.map((blob) => blob.type)).toEqual([
+            "application/wasm",
+            "application/wasm"
+        ]);
+        expect(await Promise.all(blobs.map(readBlobBytes))).toEqual([
+            Array.from(rootBytes),
+            Array.from(nestedBytes)
+        ]);
+        expect(revokeObjectURL.mock.calls).toEqual([
+            ["blob:plugin-1"],
+            ["blob:plugin-2"]
+        ]);
+    });
+
+    it("revokes plugin URLs when Csound initialization fails", async () => {
+        const plugin = makeDocument({ filename: "broken.wasm" });
+        const loadBinaryDocument = vi.fn(async () => new Uint8Array([1, 2]));
+        const createObjectURL = vi.fn(() => "blob:broken-plugin");
+        const revokeObjectURL = vi.fn();
+        const csoundFactory = vi.fn(async () => {
+            throw new Error("initialization failed");
+        });
+
+        await expect(
+            createCsoundForProject({
+                csoundFactory: csoundFactory as unknown as BrowserCsoundFactory,
+                loadBinaryDocument,
+                projectUid: "project",
+                documents: { plugin },
+                options: { useWorker: false },
+                createObjectURL,
+                revokeObjectURL
+            })
+        ).rejects.toThrow("initialization failed");
+
+        expect(revokeObjectURL).toHaveBeenCalledWith("blob:broken-plugin");
+    });
+
+    it("initializes with an empty plugin list when the project has no plugins", async () => {
+        const loadBinaryDocument = vi.fn();
+        const csoundFactory = vi.fn(async () => undefined);
+
+        await createCsoundForProject({
+            csoundFactory: csoundFactory as unknown as BrowserCsoundFactory,
+            loadBinaryDocument,
+            projectUid: "project",
+            documents: {
+                audio: makeDocument({ filename: "sample.wav" })
+            },
+            options: { useWorker: true }
+        });
+
+        expect(loadBinaryDocument).not.toHaveBeenCalled();
+        expect(csoundFactory).toHaveBeenCalledWith({
+            useWorker: true,
+            withPlugins: []
+        });
+    });
+});

--- a/src/components/csound/plugins.ts
+++ b/src/components/csound/plugins.ts
@@ -1,0 +1,66 @@
+import type { Csound as BrowserCsoundFactory } from "@csound/browser";
+import type { IDocument } from "@comp/projects/types";
+
+type CsoundInitializationOptions = Omit<
+    NonNullable<Parameters<BrowserCsoundFactory>[0]>,
+    "withPlugins"
+>;
+
+type LoadBinaryDocument = (
+    projectUid: string,
+    document: IDocument
+) => Promise<Uint8Array>;
+
+type CreateCsoundForProjectArguments = {
+    csoundFactory: BrowserCsoundFactory;
+    loadBinaryDocument: LoadBinaryDocument;
+    projectUid: string;
+    documents: Record<string, IDocument>;
+    options: CsoundInitializationOptions;
+    createObjectURL?: (blob: Blob) => string;
+    revokeObjectURL?: (url: string) => void;
+};
+
+// TODO: Check the WebAssembly magic header before loading the file.
+const isCsoundPlugin = (document: IDocument): boolean =>
+    document.type === "bin" &&
+    document.filename.toLowerCase().endsWith(".wasm");
+
+export const createCsoundForProject = async ({
+    csoundFactory,
+    loadBinaryDocument,
+    projectUid,
+    documents,
+    options,
+    createObjectURL = (blob) => URL.createObjectURL(blob),
+    revokeObjectURL = (url) => URL.revokeObjectURL(url)
+}: CreateCsoundForProjectArguments): ReturnType<BrowserCsoundFactory> => {
+    const pluginDocuments = Object.values(documents).filter(isCsoundPlugin);
+    const pluginUrls: string[] = [];
+
+    try {
+        const pluginBinaries = await Promise.all(
+            pluginDocuments.map((document) =>
+                loadBinaryDocument(projectUid, document)
+            )
+        );
+
+        for (const binary of pluginBinaries) {
+            pluginUrls.push(
+                createObjectURL(
+                    new Blob([binary], { type: "application/wasm" })
+                )
+            );
+        }
+
+        return await csoundFactory({
+            ...options,
+            // The package types say object[], but its runtime fetches URL strings.
+            withPlugins: pluginUrls as unknown as object[]
+        });
+    } finally {
+        for (const pluginUrl of pluginUrls) {
+            revokeObjectURL(pluginUrl);
+        }
+    }
+};

--- a/src/components/projects/utils.tsx
+++ b/src/components/projects/utils.tsx
@@ -140,16 +140,8 @@ export const addDocumentToCsoundFS = async (
     }
 
     if (document.type === "bin") {
-        const path = `${document.userUid}/${projectUid}/${document.documentUid}`;
         try {
-            const downloadUrl = await getDownloadURL(
-                await storageReference(path)
-            );
-            const binary = await fetchBinaryDocument(
-                downloadUrl,
-                projectUid,
-                document
-            );
+            const binary = await loadBinaryDocument(projectUid, document);
             await csound.fs.writeFile(absolutePath, binary);
         } catch (error) {
             console.error(error);
@@ -194,6 +186,11 @@ const fetchBinaryDocument = async (
 
     if (!hasCacheStorage) {
         const response = await fetch(downloadUrl);
+        if (!response.ok) {
+            throw new Error(
+                `Failed to download binary document: ${response.status}`
+            );
+        }
         const arrayBuffer = await response.arrayBuffer();
         return new Uint8Array(arrayBuffer);
     }
@@ -236,6 +233,16 @@ const fetchBinaryDocument = async (
     const networkBuffer = await networkResponse.arrayBuffer();
 
     return new Uint8Array(networkBuffer);
+};
+
+export const loadBinaryDocument = async (
+    projectUid: string,
+    document: IDocument
+): Promise<Uint8Array> => {
+    const path = `${document.userUid}/${projectUid}/${document.documentUid}`;
+    const downloadUrl = await getDownloadURL(await storageReference(path));
+
+    return fetchBinaryDocument(downloadUrl, projectUid, document);
 };
 
 export const fileDocumentDataToDocumentType = (

--- a/src/elements/filetype-icons.test.ts
+++ b/src/elements/filetype-icons.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getFileTypeIconDetails } from "./filetype-icons";
+
+describe("getFileTypeIconDetails", () => {
+    it("recognizes WebAssembly files by extension", () => {
+        expect(getFileTypeIconDetails("engine.wasm")).toEqual({
+            kind: "wasm"
+        });
+        expect(getFileTypeIconDetails("ENGINE.WASM")).toEqual({
+            kind: "wasm"
+        });
+    });
+
+    it("recognizes WebAssembly files by MIME type", () => {
+        expect(
+            getFileTypeIconDetails("engine.bin", "application/wasm")
+        ).toEqual({ kind: "wasm" });
+    });
+
+    it("leaves unrelated binary files on the default icon", () => {
+        expect(
+            getFileTypeIconDetails("engine.bin", "application/octet-stream")
+        ).toBeNull();
+    });
+});

--- a/src/elements/filetype-icons.tsx
+++ b/src/elements/filetype-icons.tsx
@@ -17,6 +17,9 @@ export type FileTypeIconDetails =
           category: CsoundFileCategory;
       }
     | {
+          kind: "wasm";
+      }
+    | {
           kind: "media";
           category: MediaFileCategory;
           label: string;
@@ -78,6 +81,10 @@ export function getFileTypeIconDetails(
     const normalizedMimeType =
         mimeType?.toLowerCase() || mime.getType(filename) || "";
 
+    if (extension === ".wasm" || normalizedMimeType === "application/wasm") {
+        return { kind: "wasm" };
+    }
+
     if (sampleExtensions.has(extension)) {
         return {
             kind: "media",
@@ -135,6 +142,10 @@ export function FileTypeIcon({
         return null;
     }
 
+    if (iconDetails.kind === "wasm") {
+        return <WasmFileIcon />;
+    }
+
     if (iconDetails.kind === "media") {
         return (
             <MediaFileIcon
@@ -158,17 +169,12 @@ export function FileTypeIcon({
     }
 }
 
-function FileIconBadge({
-    label,
-    panel,
-    shadow
+function FileIconDocument({
+    children
 }: {
-    label: string;
-    panel: string;
-    shadow: string;
+    children: React.ReactNode;
 }): React.ReactElement {
     const theme = useTheme();
-    const normalizedLabel = label.trim().slice(0, 3).toUpperCase() || "???";
 
     return (
         <svg
@@ -177,6 +183,8 @@ function FileIconBadge({
             height="512"
             viewBox="0 0 512 512"
             xmlSpace="preserve"
+            aria-hidden="true"
+            focusable="false"
         >
             {/* Paper body — theme-aware so it fits dark & light themes */}
             <path
@@ -198,6 +206,25 @@ function FileIconBadge({
                 fill={theme.line}
                 d="M260 39.219V116c0 17.645 14.355 32 32 32h100.13L260 39.219z"
             />
+            {children}
+        </svg>
+    );
+}
+
+function FileIconBadge({
+    label,
+    panel,
+    shadow
+}: {
+    label: string;
+    panel: string;
+    shadow: string;
+}): React.ReactElement {
+    const theme = useTheme();
+    const normalizedLabel = label.trim().slice(0, 3).toUpperCase() || "???";
+
+    return (
+        <FileIconDocument>
             {/* Shadow for type panel */}
             <rect
                 x="88"
@@ -229,7 +256,7 @@ function FileIconBadge({
             >
                 {normalizedLabel}
             </text>
-        </svg>
+        </FileIconDocument>
     );
 }
 
@@ -286,5 +313,31 @@ export function UdoFileIcon(): React.ReactElement {
             panel={theme.fileIcons.udo.panel}
             shadow={theme.fileIcons.udo.shadow}
         />
+    );
+}
+
+export function WasmFileIcon(): React.ReactElement {
+    const theme = useTheme();
+    const { panel, shadow } = theme.fileIcons.wasm;
+
+    return (
+        <FileIconDocument>
+            <rect
+                x="128"
+                y="196"
+                width="256"
+                height="256"
+                fill={shadow}
+                opacity="0.25"
+            />
+            <rect x="128" y="188" width="256" height="256" fill="#FFFFFF" />
+            {/* WebAssembly mark by Carlos Baraza, CC0 1.0 */}
+            <path
+                fill={panel}
+                fillRule="evenodd"
+                transform="translate(128 188) scale(10.6667)"
+                d="M14.745 0v.129a2.752 2.752 0 0 1-5.504 0V0H0v24h24V0h-9.255Zm-3.291 21.431-1.169-5.783h-.02l-1.264 5.783H7.39l-1.824-8.497h1.59l1.088 5.783h.02l1.311-5.783h1.487l1.177 5.854h.02l1.242-5.854h1.561l-2.027 8.497h-1.581Zm8.755 0-.542-1.891h-2.861l-.417 1.891h-1.59l2.056-8.497h2.509l2.5 8.497h-1.655Zm-2.397-6.403-.694 3.118h2.159l-.796-3.118h-.669Z"
+            />
+        </FileIconDocument>
     );
 }

--- a/src/styles/_theme-dracula.ts
+++ b/src/styles/_theme-dracula.ts
@@ -41,7 +41,8 @@ const theme = {
         audio: { panel: "#F29A2E", shadow: "#9C4E16" },
         midi: { panel: "#2BAE9C", shadow: "#15594F" },
         sample: { panel: "#7D69D6", shadow: "#43367A" },
-        media: { panel: "#5A88B5", shadow: "#294662" }
+        media: { panel: "#5A88B5", shadow: "#294662" },
+        wasm: { panel: "#654FF0", shadow: "#37259F" }
     }
 };
 

--- a/src/styles/_theme-github-light.ts
+++ b/src/styles/_theme-github-light.ts
@@ -80,7 +80,8 @@ const theme = {
         audio: { panel: "#F29A2E", shadow: "#9C4E16" },
         midi: { panel: "#2BAE9C", shadow: "#15594F" },
         sample: { panel: "#7D69D6", shadow: "#43367A" },
-        media: { panel: "#5A88B5", shadow: "#294662" }
+        media: { panel: "#5A88B5", shadow: "#294662" },
+        wasm: { panel: "#654FF0", shadow: "#37259F" }
     }
 };
 

--- a/src/styles/_theme-github.ts
+++ b/src/styles/_theme-github.ts
@@ -80,7 +80,8 @@ const theme = {
         audio: { panel: "#F29A2E", shadow: "#9C4E16" },
         midi: { panel: "#2BAE9C", shadow: "#15594F" },
         sample: { panel: "#7D69D6", shadow: "#43367A" },
-        media: { panel: "#5A88B5", shadow: "#294662" }
+        media: { panel: "#5A88B5", shadow: "#294662" },
+        wasm: { panel: "#654FF0", shadow: "#37259F" }
     }
 };
 

--- a/src/styles/_theme-monokai.ts
+++ b/src/styles/_theme-monokai.ts
@@ -110,7 +110,8 @@ const theme = {
         audio: { panel: "#F29A2E", shadow: "#9C4E16" },
         midi: { panel: "#2BAE9C", shadow: "#15594F" },
         sample: { panel: "#7D69D6", shadow: "#43367A" },
-        media: { panel: "#5A88B5", shadow: "#294662" }
+        media: { panel: "#5A88B5", shadow: "#294662" },
+        wasm: { panel: "#654FF0", shadow: "#37259F" }
     }
 };
 

--- a/src/styles/_theme-nord.ts
+++ b/src/styles/_theme-nord.ts
@@ -41,7 +41,8 @@ const theme = {
         audio: { panel: "#F29A2E", shadow: "#9C4E16" },
         midi: { panel: "#2BAE9C", shadow: "#15594F" },
         sample: { panel: "#7D69D6", shadow: "#43367A" },
-        media: { panel: "#5A88B5", shadow: "#294662" }
+        media: { panel: "#5A88B5", shadow: "#294662" },
+        wasm: { panel: "#654FF0", shadow: "#37259F" }
     }
 };
 

--- a/src/styles/_theme-solarized-dark.ts
+++ b/src/styles/_theme-solarized-dark.ts
@@ -41,7 +41,8 @@ const theme = {
         audio: { panel: "#F29A2E", shadow: "#9C4E16" },
         midi: { panel: "#2BAE9C", shadow: "#15594F" },
         sample: { panel: "#7D69D6", shadow: "#43367A" },
-        media: { panel: "#5A88B5", shadow: "#294662" }
+        media: { panel: "#5A88B5", shadow: "#294662" },
+        wasm: { panel: "#654FF0", shadow: "#37259F" }
     }
 };
 

--- a/src/styles/emotion.d.ts
+++ b/src/styles/emotion.d.ts
@@ -90,6 +90,7 @@ declare module "@emotion/react" {
             midi: { panel: string; shadow: string };
             sample: { panel: string; shadow: string };
             media: { panel: string; shadow: string };
+            wasm: { panel: string; shadow: string };
         };
     }
 }


### PR DESCRIPTION
## Changes

- Add a clear `.wasm` icon to the file tree.
- Load every binary `.wasm` file in a project as a Csound plugin.
- Apply plugin loading to CSD play, ORC play, and disk render.
- Reuse cached file bytes and clean up temporary URLs.

## Result

Projects can carry their Csound plugins with their other files.

## Follow-up

- Check the WebAssembly magic header before loading.
